### PR TITLE
[SNMP] added rfc 2578 compliant instance support

### DIFF
--- a/conpot/snmp/snmp_server.py
+++ b/conpot/snmp/snmp_server.py
@@ -39,8 +39,14 @@ class SNMPServer(object):
             mib_name = mib.attrib['name']
             for symbol in mib:
                 symbol_name = symbol.attrib['name']
+
+                try:
+                    symbol_instance = tuple(int(i) for i in symbol.attrib['instance'].split('.'))
+                except KeyError:
+                    symbol_instance = (0,)
+
                 value = symbol.xpath('./value/text()')[0]
-                self.cmd_responder.register(mib_name, symbol_name, value)
+                self.cmd_responder.register(mib_name, symbol_name, symbol_instance, value)
 
     def start(self):
         if self.cmd_responder:

--- a/conpot/tests/test_snmp_server.py
+++ b/conpot/tests/test_snmp_server.py
@@ -49,8 +49,12 @@ class TestBase(unittest.TestCase):
             mib_name = mib.attrib['name']
             for symbol in mib:
                 symbol_name = symbol.attrib['name']
+                try:
+                    symbol_instance = tuple(int(i) for i in symbol.attrib['instance'].split('.'))
+                except KeyError:
+                    symbol_instance = (0,)
                 value = symbol.xpath('./value/text()')[0]
-                self.snmp_server.register(mib_name, symbol_name, value)
+                self.snmp_server.register(mib_name, symbol_name, symbol_instance, value)
         self.snmp_server.snmpEngine.transportDispatcher.start()
 
     def tearDown(self):


### PR DESCRIPTION
It's done :) ... onward to the very first pull request in my life ( disregarding the request I canceled yesterday :P ).
#### Instance support

Instance support is now working in compliance with rfc 2578 -
to achieve this, an additional XML "instance" property was added to the template -
if property does not exist, instance "0" is being assumed.

Tested with the following symbols:

``` xml
 <mib name="IF-MIB">

                <symbol name="ifNumber">
                    <value>2</value>
                </symbol>

                <symbol name="ifIndex" instance="1">
                    <value>1</value>
                </symbol>

                <symbol name="ifIndex" instance="2">
                    <value>2</value>
                </symbol>

                <symbol name="ifDescr" instance="1">
                    <value>Ethernet Port 0, link, 100 Mbit, full duplex, autonegotiation</value>
                </symbol>

                <symbol name="ifDescr" instance="2">
                    <value>Ethernet Port 1, link, 100 Mbit, full duplex, autonegotiation</value>
                </symbol>

</mib>

<mib name="IP-MIB">
    <symbol name="ipAdEntIfIndex" instance="192.168.1.200">
        <value>1</value>
    </symbol>
</mib>

```
#### Error handling for unknown symbols

conpot now informs the user of symbols it could not find within a
MIB and skips the respective XML stanza instead of crashing.
