### PR TITLE
Log fail of http payload retrieval from filesystem

### DIFF
--- a/conpot/http/command_responder.py
+++ b/conpot/http/command_responder.py
@@ -163,7 +163,8 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                 with open(docpath + '/statuscodes/' + str(status) + '.status', 'rb') as f:
                     payload = f.read()
 
-            except IOError:
+            except IOError, e:
+                logger.error('{0}'.format(e))
                 payload = ''
 
             # there might be template data that can be substituted within the


### PR DESCRIPTION
hi, this error log saves a lot of debugging

when -w parameter is not correct
