### PR TITLE
UTF8 decode portion of url for XML in http command_responder

### DIFF
--- a/conpot/http/command_responder.py
+++ b/conpot/http/command_responder.py
@@ -590,7 +590,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
 
             # try to find a configuration item for this GET request
             entity_xml = configuration.xpath('//conpot_template/http/htdocs/node[@name="' +
-                                             self.path.partition('?')[0] + '"]')
+                              self.path.partition('?')[0].decode('utf8') + '"]')
 
             if entity_xml:
                 # A config item exists for this entity. Handle it..
@@ -721,7 +721,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
 
         # try to find a configuration item for this GET request
         entity_xml = configuration.xpath('//conpot_template/http/htdocs/node[@name="' +
-                                         self.path.partition('?')[0] + '"]')
+                              self.path.partition('?')[0].decode('utf8') + '"]')
 
         if entity_xml:
             # A config item exists for this entity. Handle it..
@@ -781,7 +781,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
 
         # try to find a configuration item for this POST request
         entity_xml = configuration.xpath('//conpot_template/http/htdocs/node[@name="' +
-                                         self.path.partition('?')[0] + '"]')
+                              self.path.partition('?')[0].decode('utf8') + '"]')
 
         if entity_xml:
             # A config item exists for this entity. Handle it..


### PR DESCRIPTION
so
GET http://domainÂ:Â HTTP/1.1

won't trigger Traceback

```
Traceback (most recent call last):
  File "/usr/lib64/python2.7/SocketServer.py", line 582, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib64/python2.7/SocketServer.py", line 323, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib64/python2.7/SocketServer.py", line 639, in __init__
    self.handle()
  File "/usr/lib64/python2.7/BaseHTTPServer.py", line 337, in handle
    self.handle_one_request()
  File "/usr/lib64/python2.7/BaseHTTPServer.py", line 325, in handle_one_request
    method()
  File "/usr/local/lib/python2.7/site-packages/Conpot-0.2.2-py2.7.egg/conpot/http/command_responder.py", line 593, in do_HEAD
    self.path.partition('?')[0] + '"]')
  File "lxml.etree.pyx", line 1833, in lxml.etree._ElementTree.xpath (src/lxml/lxml.etree.c:42103)
  File "xpath.pxi", line 326, in lxml.etree.XPathDocumentEvaluator.__call__ (src/lxml/lxml.etree.c:104333)
  File "apihelpers.pxi", line 1295, in lxml.etree._utf8 (src/lxml/lxml.etree.c:20212)
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes
```
