### PR TITLE
Proxy: POST method awareness and Header transparency

### DIFF
--- a/conpot/protocols/http/command_responder.py
+++ b/conpot/protocols/http/command_responder.py
@@ -176,7 +176,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
         # retrieve and return (substituted) payload
         return parser.payload
 
-    def load_status(self, status, requeststring, headers, configuration, docpath):
+    def load_status(self, status, requeststring, headers, configuration, docpath, method='GET', body=None):
         """Retrieves headers and payload for a given status code.
            Certain status codes can be configured to forward the
            request to a remote system. If not available, generate
@@ -272,7 +272,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
             try:
 
                 conn = httplib.HTTPConnection(target)
-                conn.request("GET", requeststring)
+                conn.request(method, requeststring, body)
                 response = conn.getresponse()
 
                 status = int(response.status)
@@ -797,7 +797,8 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                                                                             self.path,
                                                                             headers,
                                                                             configuration,
-                                                                            docpath)
+                                                                            docpath,
+                                                                            'GET')
 
         # send initial HTTP status line to client
         self.send_response(status)
@@ -858,7 +859,9 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                                                                             self.path,
                                                                             headers,
                                                                             configuration,
-                                                                            docpath)
+                                                                            docpath,
+                                                                            'POST',
+                                                                            post_data)
 
         # send initial HTTP status line to client
         self.send_response(status)

--- a/conpot/protocols/http/command_responder.py
+++ b/conpot/protocols/http/command_responder.py
@@ -27,7 +27,6 @@ from SocketServer import ThreadingMixIn
 import BaseHTTPServer
 import httplib
 import os
-import sys
 from lxml import etree
 
 import conpot.core as conpot_core
@@ -276,7 +275,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                 requestheaders['Host'] = target
                 requestheaders['Connection'] = 'close'
 
-		remotestatus = 0
+                remotestatus = 0
                 conn = httplib.HTTPConnection(target)
                 conn.request(method, requeststring, body, dict(requestheaders))
                 response = conn.getresponse()
@@ -295,7 +294,7 @@ class HTTPServer(BaseHTTPServer.BaseHTTPRequestHandler):
                         del headers[i]
                         break
 
-		status = remotestatus
+                status = remotestatus
 
             except:
 


### PR DESCRIPTION
Up 'til now, POST requests were converted to GET requests.
This PR handles POST requests separately while handing over the original request headers (except for headers that are mangled to fit the new http source).

Travis seems to be unhappy ... not sure why it is stuck at unit tests ...