### PR TITLE
Remove telize as ip lookup service

### DIFF
--- a/conpot/conpot.cfg
+++ b/conpot/conpot.cfg
@@ -50,7 +50,7 @@ use_https = False
 
 [fetch_public_ip]
 enabled = True
-urls = ["http://www.telize.com/ip", "http://queryip.net/ip/", "http://ifconfig.me/ip"]
+urls = ["http://queryip.net/ip/", "http://ifconfig.me/ip"]
 
 [change_mac_addr]
 enabled = False

--- a/conpot/utils/ext_ip.py
+++ b/conpot/utils/ext_ip.py
@@ -65,4 +65,4 @@ def get_ext_ip(config=None, urls=None):
 
 
 if __name__ == "__main__":
-    print get_ext_ip(urls=["http://www.telize.com/ip", "http://queryip.net/ip/", "http://ifconfig.me/ip"])
+    print get_ext_ip(urls=["http://queryip.net/ip/", "http://ifconfig.me/ip"])


### PR DESCRIPTION
Removes telize, which shut down on 2015-11-15 (see http://www.telize.com/)