### PR TITLE
Fix v2c support

### DIFF
--- a/conpot/protocols/snmp/command_responder.py
+++ b/conpot/protocols/snmp/command_responder.py
@@ -99,6 +99,8 @@ class CommandResponder(object):
         # Allow full MIB access for each user at VACM
         config.addVacmUser(self.snmpEngine, 1, 'public-read', 'noAuthNoPriv',
                            readSubTree=(1, 3, 6, 1, 2, 1), writeSubTree=(1, 3, 6, 1, 2, 1))
+        config.addVacmUser(self.snmpEngine, 2, 'public-read', 'noAuthNoPriv',
+                           readSubTree=(1, 3, 6, 1, 2, 1), writeSubTree=(1, 3, 6, 1, 2, 1))
         config.addVacmUser(self.snmpEngine, 3, 'usr-md5-des', 'authPriv',
                            readSubTree=(1, 3, 6, 1, 2, 1), writeSubTree=(1, 3, 6, 1, 2, 1))
         config.addVacmUser(self.snmpEngine, 3, 'usr-sha-none', 'authNoPriv',


### PR DESCRIPTION
Fixes #289 and #292

Before:

```
$  snmpwalk -v2c -c public localhost 
Error in packet.
Reason: authorizationError (access denied to that object)
Failed object: SNMPv2-SMI::mib-2

SNMPv2-SMI::mib-2 = No Such Object available on this agent at this OID
```

After:

```
$  snmpwalk -v2c -c public localhost 
SNMPv2-MIB::sysDescr.0 = STRING: Siemens, SIMATIC, S7-200
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.20408
DISMAN-EVENT-MIB::sysUpTimeInstance = Timeticks: (1) 0:00:00.01
SNMPv2-MIB::sysContact.0 = STRING: Siemens AG
SNMPv2-MIB::sysName.0 = STRING: CP 443-1 EX40
...
```