### PR TITLE
remove libsmi2ldbl and snmp-mibs-downloader dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ RUN sed -i -e 's/main/main non-free contrib/g' /etc/apt/sources.list
 # Install dependencies
 RUN apt-get update -y -qq && apt-get install -y -qq \
         libmysqlclient-dev \
-        libsmi2ldbl \
-        libxslt1-dev \
-        snmp-mibs-downloader && \
+        libxslt1-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -19,7 +17,11 @@ COPY ./ /opt/conpot/
 WORKDIR /opt/conpot
 
 # Install Python requirements
+RUN pip install --no-cache-dir coverage
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Run test cases
+RUN coverage run --timid --source=conpot setup.py test
 
 # Install the Conpot application
 RUN python setup.py install

--- a/conpot/protocols/snmp/build_pysnmp_mib_wrapper.py
+++ b/conpot/protocols/snmp/build_pysnmp_mib_wrapper.py
@@ -21,6 +21,7 @@ import os
 import re
 
 from pysmi.reader.localfile import FileReader
+from pysmi.reader.httpclient import HttpReader
 from pysmi.searcher.pyfile import PyFileSearcher
 from pysmi.searcher.pypackage import PyPackageSearcher
 from pysmi.searcher.stub import StubSearcher
@@ -55,9 +56,8 @@ def mib2pysnmp2(mib_file, output_dir):
     mibCompiler = MibCompiler(SmiV2Parser(), PySnmpCodeGen(),
                               PyFileWriter(output_dir))
 
-    # add default sources and mib_file's location
-    mibCompiler.addSources(FileReader('/usr/share/mibs/ietf'))
-    mibCompiler.addSources(FileReader('/usr/share/mibs/iana'))
+    # add sources from where we fetch dependencies
+    mibCompiler.addSources(HttpReader('mibs.snmplabs.com', 80, '/asn1/@mib@'))
     mibCompiler.addSources(
         FileReader(os.path.dirname(os.path.abspath(mib_file))))
 
@@ -78,6 +78,7 @@ def mib2pysnmp2(mib_file, output_dir):
 
 def mib2pysnmp(mib_file):
     """
+    Deprecated
     Wraps the 'build-pysnmp-mib' script.
     :param mib_file: Path to the MIB file.
     :return: A string representation of the compiled MIB file (string).


### PR DESCRIPTION
We let pysmi automatically download mib files from a remote repo. 