### PR TITLE
install modbus-tk from pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ cybox
 bacpypes==0.13.8
 pyghmi
 mixbox
+modbus-tk

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     tests_require="nose",
     dependency_links=[
         "https://github.com/rep/hpfeeds/archive/master.zip#egg=hpfeeds",
-        "https://github.com/ljean/modbus-tk/archive/master.zip#egg=modbus-tk"
     ],
     install_requires=open('requirements.txt').read().splitlines(),
 )


### PR DESCRIPTION
Remove modbus-tk repo link from `setup.py`, add modbus-tk into `requirements.txt`