### PR TITLE
Break out port and ip in logger output

### DIFF
--- a/conpot/core/attack_session.py
+++ b/conpot/core/attack_session.py
@@ -45,7 +45,11 @@ class AttackSession(object):
         data = {
             "id": self.id,
             "remote": (self.source_ip, self.source_port),
+            "src_ip": self.source_ip,
+            "src_port": self.source_port,
             "local": (self.destination_ip, self.destination_port),
+            "dst_ip": self.destination_ip,
+            "dst_port": self.destination_port,
             "data_type": self.protocol,
             "timestamp": self.timestamp,
             "public_ip": self.public_ip,
@@ -66,7 +70,11 @@ class AttackSession(object):
         data = {
             "id": self.id,
             "remote": (self.source_ip, self.source_port),
+            "src_ip": self.source_ip,
+            "src_port": self.source_port,
             "local": (self.destination_ip, self.destination_port),
+            "dst_ip": self.destination_ip,
+            "dst_port": self.destination_port,
             "data_type": self.protocol,
             "timestamp": self.timestamp,
             "public_ip": self.public_ip,


### PR DESCRIPTION
I'm a hpfeeds user. I would be a much happier conpot user if it was closer to the json output.

This PR is a step towards this - it breaks out src ip/port and dst ip/port into seperate fields. It leaves the other fields there for now as I don't want to break other hpfeeds users.

A specific example where the current schema is annoying in ES. If i feed the conpot event stream via hpfeeds as is it will choke ES - it does not like mixed type tuples (these fields are str/int).

