### PR TITLE
fixed bug in config path

### DIFF
--- a/bin/conpot
+++ b/bin/conpot
@@ -221,10 +221,9 @@ def main():
                   ' running Conpot')
             sys.exit(3)
         try:
-            if not os.path.isfile(os.path.join(package_directory, args.config)):
+            if not os.path.join(args.config):
                 raise FileNotFoundError('Config file not found!')
-            args.config = os.path.join(package_directory, args.config)
-            logger.info('Config file found!')
+                logger.info('Config file found!')
             config.read(args.config)
         except FileNotFoundError:
             logger.exception('\nCould not find config file!\nUse -f option to try the test configuration')


### PR DESCRIPTION
This pull request fixes issue https://github.com/mushorg/conpot/issues/413 

The problem was:  _-c_ option didn´t get the correct config file if it was not in the _package_directory_ path, so the file needed to stay in a fixed directory.

Now, is possible to have _conpot.cfg_ in a user-defined folder and just write _-c path_