### PR TITLE
Fix s7 parameter length calculation

### DIFF
--- a/conpot/protocols/s7comm/s7.py
+++ b/conpot/protocols/s7comm/s7.py
@@ -21,8 +21,8 @@ class S7(object):
         self.pdu_type = pdu_type
         self.reserved = reserved
         self.request_id = request_id
-        # sometimes "parameters" happen to be of type int, not str
-        self.param_length = len(str(parameters))
+        # sometimes "parameters" happen to be of type int, and not a byte string
+        self.param_length = len(parameters) if isinstance(parameters, bytes) else len(str(parameters))
         self.data_length = len(data)
         self.result_info = result_info
         self.parameters = parameters


### PR DESCRIPTION
## Description
This pull request fixes the `param_length` calculation for the s7comm protocol introduced in the python3 migration

## Motivation and Context
Python3 clearly separates text (`str` type  - unicode code points) from byte strings (class `bytes`). The `struct` module which conpot uses returns byte strings by default in py3. Unlike py2, `str` and `bytes` objects cannot be used interchangeably. The `parameters` variable in s7.py, according to the comment can either be a string or an integer. To simplify the code, conpot by default converts the value to a string before computing the length. In python3, by doing this (and if the variable is a byte string), we are appending `b'` to the original value resulting in an incorrect length calculation as exemplified below:

```
Python 3.7.0 (default, Aug 22 2018, 15:22:33)
[Clang 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> foo_str = "bar"
>>> foo_b = b"bar"
>>> len(foo_str)
3
>>> len(foo_b)
3
>>> str(foo_b)
"b'bar'"
>>> len(str(foo_b))
6
```
This results in a wrong playload when `pack` is called. For instance, using the default conpot template, the version in **master** returns:

<pre>
b'\x03\x00\x015\x02\xf0\x802\x07\x00\x00\x00<b>\x00\x00#\x01\x1c</b>\x00\x01\x12\x08\x12\x84\x01\x01\xff\t\x01\x18\x00\x1c\x00\x01\x00"\x00\x08\x00\x01Technodrome\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02Siemens, SIMATIC, S7-200\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03Mouser Factory\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04Original Siemens Equipment\x00\x00\x00\x00\x00\x00\x00\x0588111222\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07IM151-8 PN/DP CPU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
</pre>

instead of:

<pre>
b'\x03\x00\x015\x02\xf0\x802\x07\x00\x00\x00\x00<b>\x00\x08\x01\x1c</b>\x00\x01\x12\x08\x12\x84\x01\x01\xff\t\x01\x18\x00\x1c\x00\x01\x00"\x00\x08\x00\x01Technodrome\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02Siemens, SIMATIC, S7-200\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03Mouser Factory\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04Original Siemens Equipment\x00\x00\x00\x00\x00\x00\x00\x0588111222\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x07IM151-8 PN/DP CPU\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
</pre>

## How Has This Been Tested?
Using plcscan (https://github.com/meeas/plcscan) against the honeypot.

Master:
```
[root@inventorydb plcscan]# python plcscan.py 172.27.101.241 --p 10201
Scan start...
172.27.101.241:10201 [Errno 104] Connection reset by peer
172.27.101.241:10201 S7comm (src_tsap=0x100, dst_tsap=0x102)
Scan complete
```

This PR:

```
[root@inventorydb plcscan]# python plcscan.py 172.27.101.241 --p 10201
Scan start...
172.27.101.241:10201 [Errno 104] Connection reset by peer
172.27.101.241:10201 S7comm (src_tsap=0x100, dst_tsap=0x102)
  Module                   :  v.0.0                        	(0000000000000000000000000000000000000000000000000000)
  Name of the PLC          : Technodrome                   	(546563686e6f64726f6d65000000000000000000000000000000000000000000)
  Name of the module       : Siemens, SIMATIC, S7-200      	(5369656d656e732c2053494d415449432c2053372d3230300000000000000000)
  Plant identification     : Mouser Factory                	(4d6f7573657220466163746f7279000000000000000000000000000000000000)
  Copyright                : Original Siemens Equipment    	(4f726967696e616c205369656d656e732045717569706d656e74000000000000)
  Serial number of module  : 88111222                      	(3838313131323232000000000000000000000000000000000000000000000000)
  Module type name         : IM151-8 PN/DP CPU             	(494d3135312d3820504e2f445020435055000000000000000000000000000000)
  OEM ID of a module       :                                 	(0000000000000000000000000000000000000000000000000000000000000000)
  Location designation of a module:                                 	(0000000000000000000000000000000000000000000000000000000000000000)
Scan complete
```
## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)


