### PR TITLE
Fixed wrong Docker ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Navigate to ``http://MY_IP_ADDRESS`` to confirm the setup.
 1. Install [Docker](https://docs.docker.com/engine/installation/)
 2. Clone this repo with `git clone https://github.com/mushorg/conpot.git` and `cd conpot/docker`
 3. Run `docker build -t conpot .`
-4. Run `docker run -it -p 80:8800 -p 102:10201 -p 502:5020 -p 161:16100/udp -p 47808:47808 -p 623:6230 -p 21:2121 -p 69:6969/udp -p 44818:44818 --network=bridge conpot`
+4. Run `docker run -it -p 80:8800 -p 102:10201 -p 502:5020 -p 161:16100/udp -p 47808:47808/udp -p 623:6230/udp -p 21:2121 -p 69:6969/udp -p 44818:44818 --network=bridge conpot`
 
 Navigate to `http://MY_IP_ADDRESS` to confirm the setup. 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,8 +7,8 @@ services:
      - "102:10201" #S7Comm
      - "502:5020" #Modbus
      - "161:16100/udp" #SNMP
-     - "47808:47808" #Bacnet
-     - "623:6230" #IPMI
+     - "47808:47808/udp" #Bacnet
+     - "623:6230/udp" #IPMI
      - "21:2121" #FTP
      - "69:6969/udp" #TFTP
      - "44818:44818" #EN/IP


### PR DESCRIPTION
The BACnet and IPMI ports are listed as TCP, but these services are actually UDP.