### PR TITLE
Fix scapy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ libtaxii>=1.1.0
 xlrd
 crc16
 natsort
-scapy
+scapy==2.4.3rc1
 enum34
 hpfeeds3
 modbus-tk


### PR DESCRIPTION
Scapy has a pip requirements bug in 2.4.2, which is currently installed by default. We're pinning it to 2.4.3rc1 until the default version in PIP has the fix included.