### PR TITLE
Change SNMP Port to 16100

### DIFF
--- a/conpot/templates/IEC104/snmp/snmp.xml
+++ b/conpot/templates/IEC104/snmp/snmp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<snmp enabled="True" host="0.0.0.0" port="161">
+<snmp enabled="True" host="0.0.0.0" port="16100">
     <config>
         <!-- Configure individual delays for SNMP commands -->
         <entity name="tarpit" command="get">0.1;0.2</entity>


### PR DESCRIPTION
Using port **161** requires root privileges.

Since Conpot drops root privileges on launch, Conpot **crashes** on start-up when trying to use port 161.

Changing the port from **161** to **16100**, as it is used in the default profile fixes the issue.