### PR TITLE
Avoid broken dependency freezegun 0.13.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pytest
 fs==2.3.0
 python-slugify
 tftpy
+# some freezegun versions broken
 freezegun!=0.3.13
 pytest
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pytest
 fs==2.3.0
 python-slugify
 tftpy
-freezegun
+freezegun!=0.3.13
 pytest
 tox
 pycrypto


### PR DESCRIPTION
Apparently the recently release version 0.13.3 of freezegun makes our test suite fail. (`conpot.tests.test_vfs.TestSubFileSystem.test_set_time` in particular.)

The PR only skips that particular version, in the hopes that future releases will have fixed the issue.