### PR TITLE
Fix ENIP test crashes and conpot_protocol snafu 

### DIFF
--- a/conpot/core/protocol_wrapper.py
+++ b/conpot/core/protocol_wrapper.py
@@ -27,7 +27,10 @@ def conpot_protocol(cls):
             self.wrapped = cls(*args, **kwargs)
             self.cls = cls
             if self.cls.__name__ not in 'Proxy':
-                core_interface.protocols[self.cls] = self.wrapped
+                if self.cls not in core_interface.protocols:
+                    core_interface.protocols[self.cls] = []
+
+                core_interface.protocols[self.cls].append(self.wrapped)
 
         def __getattr__(self, name):
             if name == 'handle':
@@ -35,10 +38,10 @@ def conpot_protocol(cls):
                 # enabled protocol, update the last_active (last_attacked attribute)
                 # FIXME: No handle function in HTTPServer
                 core_interface.last_active = datetime.now().strftime("%b %d %Y - %H:%M:%S")
-            return getattr(core_interface.protocols[self.cls], name)
+            return self.wrapped.__getattribute__(name)
 
         def __repr__(self):
-            return self.cls.__repr__(self.wrapped)
+            return self.wrapped.__repr__()
 
         __doc__ = property(lambda self: self.cls.__doc__)
         __module__ = property(lambda self: self.cls.__module__)

--- a/conpot/protocols/enip/enip_server.py
+++ b/conpot/protocols/enip/enip_server.py
@@ -93,8 +93,8 @@ class EnipServer(object):
         self.config = EnipConfig(template)
         self.addr = self.config.server_addr
         self.port = self.config.server_port
-        self.stopped = False
         self.connections = cpppo.dotdict()
+        self.control = None
         self.start_event = Event()
 
         # all known tags
@@ -187,7 +187,7 @@ class EnipServer(object):
                                 # that (shared) server.control.{done,disable} dotdict be in kwds.  We do
                                 # *not* read using attributes here, to avoid reporting completion to
                                 # external APIs (eg. web) awaiting reception of these signals.
-                                if kwds['server']['control']['done'] or  kwds['server']['control']['disable']:
+                                if kwds['server']['control']['done'] or kwds['server']['control']['disable']:
                                     logger.info("%s done, due to server done/disable", machine.name_centered())
                                     stats['eof'] = True
                                 if msg is not None:
@@ -315,6 +315,9 @@ class EnipServer(object):
                                 brx = cpppo.timer()
                                 msg, frm = network.recvfrom(conn, timeout=wait)
                                 now = cpppo.timer()
+                                if not msg:
+                                    if kwds['server']['control']['done'] or kwds['server']['control']['disable']:
+                                        return
                                 (logger.info if msg else logger.debug)(
                                     "Transaction receive after %7.3fs (%5s bytes in %7.3f/%7.3fs): %r",
                                     now - begun, len(msg) if msg is not None else "None",
@@ -447,18 +450,17 @@ class EnipServer(object):
         tcp_mode = True if self.config.mode == 'tcp' else False
         udp_mode = True if self.config.mode == 'udp' else False
 
+        self.control = srv_ctl.control
         self.start_event.set()
 
         logger.debug('ENIP server started on: %s:%d, mode: %s' % (host, port, self.config.mode))
-        while not self.stopped:
+        while not self.control["done"]:
             network.server_main(address=(host, port), target=self.handle,
-                                kwargs=kwargs, idle_service=None,
-                                udp=udp_mode, tcp=tcp_mode,
-                                thread_factory=network.server_thread)
+                                kwargs=kwargs, udp=udp_mode, tcp=tcp_mode)
 
     def stop(self):
         logger.debug('Stopping ENIP server')
-        self.stopped = True
+        self.control['done'] = True
         self.start_event.clear()
 
 

--- a/conpot/protocols/enip/enip_server.py
+++ b/conpot/protocols/enip/enip_server.py
@@ -23,6 +23,7 @@ import time
 import sys
 import traceback
 
+from gevent.event import Event
 from lxml import etree
 from cpppo.server import network
 from cpppo.server.enip import logix
@@ -94,6 +95,7 @@ class EnipServer(object):
         self.port = self.config.server_port
         self.stopped = False
         self.connections = cpppo.dotdict()
+        self.start_event = Event()
 
         # all known tags
         self.tags = cpppo.dotdict()
@@ -445,6 +447,8 @@ class EnipServer(object):
         tcp_mode = True if self.config.mode == 'tcp' else False
         udp_mode = True if self.config.mode == 'udp' else False
 
+        self.start_event.set()
+
         logger.debug('ENIP server started on: %s:%d, mode: %s' % (host, port, self.config.mode))
         while not self.stopped:
             network.server_main(address=(host, port), target=self.handle,
@@ -455,6 +459,7 @@ class EnipServer(object):
     def stop(self):
         logger.debug('Stopping ENIP server')
         self.stopped = True
+        self.start_event.clear()
 
 
 if __name__ == '__main__':

--- a/conpot/tests/test_enip_server.py
+++ b/conpot/tests/test_enip_server.py
@@ -30,11 +30,12 @@ class TestENIPServer(unittest.TestCase):
         self.dir_name = os.path.dirname(conpot.__file__)
         template = self.dir_name + '/templates/default/enip/enip.xml'
         # start the tcp server
-        self.enip_server_tcp= EnipServer(template, None, None)
+        self.enip_server_tcp = EnipServer(template, None, None)
         self.enip_server_tcp.port = 50002
         self.server_greenlet_tcp = gevent.spawn(self.enip_server_tcp.start, self.enip_server_tcp.addr,
                                                 self.enip_server_tcp.port)
-        self.server_greenlet_tcp.start()
+        self.enip_server_tcp.start_event.wait()
+        self.assertFalse(self.server_greenlet_tcp.exception)
 
         # start the udp server
         self.enip_server_udp = EnipServer(template, None, None)
@@ -42,7 +43,8 @@ class TestENIPServer(unittest.TestCase):
         self.enip_server_udp.port = 60002
         self.server_greenlet_udp = gevent.spawn(self.enip_server_udp.start, self.enip_server_udp.addr,
                                                 self.enip_server_udp.port)
-        self.server_greenlet_udp.start()
+        self.enip_server_udp.start_event.wait()
+        self.assertFalse(self.server_greenlet_udp.exception)
 
     def tearDown(self):
         self.enip_server_tcp.stop()

--- a/conpot/tests/test_enip_server.py
+++ b/conpot/tests/test_enip_server.py
@@ -52,7 +52,8 @@ class TestENIPServer(unittest.TestCase):
         self.server_greenlet_tcp.join()
         self.server_greenlet_udp.join()
 
-    def attribute_operations(self, paths, int_type=None, **kwds):
+    @staticmethod
+    def attribute_operations(paths, int_type=None, **kwds):
         for op in client.parse_operations(paths, int_type=int_type or 'SINT', **kwds):
             path_end = op['path'][-1]
             if 'instance' in path_end:
@@ -63,6 +64,11 @@ class TestENIPServer(unittest.TestCase):
             else:
                 raise AssertionError("Path invalid for Attribute services: %r", op['path'])
             yield op
+
+    @staticmethod
+    def await_cpf_response(connection, command):
+        response, _ = client.await_response(connection, timeout=4.0)
+        return response['enip']['CIP'][command]['CPF']
 
     def test_read_tags(self):
         with client.connector(host=self.enip_server_tcp.addr,
@@ -83,65 +89,47 @@ class TestENIPServer(unittest.TestCase):
                 elif idx == 1:
                     self.assertEqual(50, val[0])
 
-    # TCP Tests
     def test_list_services_tcp(self):
-        # test tcp
         with client.connector(host=self.enip_server_tcp.addr,
                               port=self.enip_server_tcp.port, timeout=4.0,
                               udp=False, broadcast=False) as connection:
             connection.list_services()
             connection.shutdown()
-            while True:
-                response, ela = client.await_response(connection, timeout=4.0)
-                if response:
-                    self.assertEqual("Communications",
-                                     response['enip']['CIP']['list_services']['CPF']['item'][0]['communications_service']['service_name'])
-                else:
-                    break
+            response = self.await_cpf_response(connection, 'list_services')
+
+            self.assertEqual("Communications",
+                             response['item'][0]['communications_service']['service_name'])
 
     def test_list_services_udp(self):
-        # test udp
         with client.connector(host=self.enip_server_udp.addr,
                               port=self.enip_server_udp.port, timeout=4.0,
                               udp=True, broadcast=True) as connection:
             connection.list_services()
-            # TODO: udp does not cleanly shutdown. We get OSError.
-            while True:
-                response, ela = client.await_response(connection, timeout=4.0)
-                if response:
-                    self.assertEqual("Communications",
-                                     response['enip']['CIP']['list_services']['CPF']['item'][0]['communications_service']['service_name'])
-                else:
-                    break
+            response = self.await_cpf_response(connection, 'list_services')
+
+            self.assertEqual("Communications",
+                             response['item'][0]['communications_service']['service_name'])
 
     def test_list_identity_tcp(self):
-        # test tcp
         with client.connector(host=self.enip_server_tcp.addr,
                               port=self.enip_server_tcp.port, timeout=4.0,
                               udp=False, broadcast=False) as connection:
             connection.list_identity()
             connection.shutdown()
-            while True:
-                response, ela = client.await_response(connection, timeout=4.0)
-                if response:
-                    expected = self.enip_server_tcp.config.product_name
-                    self.assertEqual(expected, response['enip']['CIP']['list_identity']['CPF']['item'][0]['identity_object']['product_name'])
-                else:
-                    break
+            response = self.await_cpf_response(connection, 'list_identity')
+
+            expected = self.enip_server_tcp.config.product_name
+            self.assertEqual(expected, response['item'][0]['identity_object']['product_name'])
 
     def test_list_identity_udp(self):
         with client.connector(host=self.enip_server_udp.addr,
                               port=self.enip_server_udp.port, timeout=4.0,
                               udp=True, broadcast=True) as connection:
             connection.list_identity()
-            # TODO: udp does not cleanly shutdown. We get OSError.
-            while True:
-                response, ela = client.await_response(connection, timeout=4.0)
-                if response:
-                    expected = self.enip_server_tcp.config.product_name
-                    self.assertEqual(expected, response['enip']['CIP']['list_identity']['CPF']['item'][0]['identity_object']['product_name'])
-                else:
-                    break
+            response = self.await_cpf_response(connection, 'list_identity')
+
+            expected = self.enip_server_tcp.config.product_name
+            self.assertEqual(expected, response['item'][0]['identity_object']['product_name'])
 
     def test_list_interfaces_tcp(self):
         with client.connector(host=self.enip_server_tcp.addr,
@@ -149,25 +137,18 @@ class TestENIPServer(unittest.TestCase):
                               udp=False, broadcast=False) as conn:
             conn.list_interfaces()
             conn.shutdown()
-            while True:
-                response, ela = client.await_response(conn, timeout=4.0)
-                if response:
-                    self.assertDictEqual({'count': 0}, response['enip']['CIP']['list_interfaces']['CPF'])
-                else:
-                    break
+            response = self.await_cpf_response(conn, 'list_interfaces')
+
+            self.assertDictEqual({'count': 0}, response)
 
     def test_list_interfaces_udp(self):
         with client.connector(host=self.enip_server_udp.addr,
                               port=self.enip_server_udp.port, timeout=4.0,
                               udp=True, broadcast=True) as conn:
             conn.list_interfaces()
-            # TODO: udp does not cleanly shutdown. We get OSError.
-            while True:
-                response, ela = client.await_response(conn, timeout=4.0)
-                if response:
-                    self.assertDictEqual({'count': 0}, response['enip']['CIP']['list_interfaces']['CPF'])
-                else:
-                    break
+            response = self.await_cpf_response(conn, 'list_interfaces')
+
+            self.assertDictEqual({'count': 0}, response)
 
     # Tests related to restart of ENIP device.. 
     # def test_send_NOP(self):

--- a/conpot/tests/test_enip_server.py
+++ b/conpot/tests/test_enip_server.py
@@ -49,6 +49,8 @@ class TestENIPServer(unittest.TestCase):
     def tearDown(self):
         self.enip_server_tcp.stop()
         self.enip_server_udp.stop()
+        self.server_greenlet_tcp.join()
+        self.server_greenlet_udp.join()
 
     def attribute_operations(self, paths, int_type=None, **kwds):
         for op in client.parse_operations(paths, int_type=int_type or 'SINT', **kwds):

--- a/conpot/tests/test_protocol_wrapper.py
+++ b/conpot/tests/test_protocol_wrapper.py
@@ -1,0 +1,26 @@
+from conpot.core.protocol_wrapper import conpot_protocol
+
+
+@conpot_protocol
+class ProtocolFake:
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return f"ProtocolFake({self.value})"
+
+
+def test_instances_have_separate_fields():
+    inst_1 = ProtocolFake(1)
+    inst_2 = ProtocolFake(2)
+
+    assert inst_1.value == 1
+    assert inst_2.value == 2
+
+
+def test_instances_have_separate_repr():
+    inst_1 = ProtocolFake(1)
+    inst_2 = ProtocolFake(2)
+
+    assert repr(inst_1) == "ProtocolFake(1)"
+    assert repr(inst_2) == "ProtocolFake(2)"


### PR DESCRIPTION
This PR fixes multiple issues that lead to the ENIP tests crashing without much notice. The root cause was a major bug in the `conpot_protocol` decorator. It also adds a few tests to catch regressions.

Another related issue is that Conpot (in both production code and test code) generally does not properly shut down greenlets. A general fix for that proved to be too big for this PR.

1. The ENIP test `setUp()` method was crashing, but the exceptions weren't propagated from the greenlets, thus going unnoticed. There's even a comment that acknowledges that there's something wrong:
   ```py
   # TODO: udp does not cleanly shutdown. We get OSError.
   ```
   The first commit exposes the crashes but does not fix anything just yet.

1. The second commit fixes `conpot_protocol` allowing only a single instance reference per class:
   ```py
   core_interface.protocols[self.cls] = self.wrapped
   [...]
   return getattr(core_interface.protocols[self.cls], name)

   ```
   **This effectively turned every decorated class into a singleton,** where earlier instances would share instance variables with the most recently created instance. This manifested itself in the ENIP tests because `setUp` creates instance for TCP and UDP, respectively.

1. The third commit fixes ENIP greenlets surviving across test runs. The UDP ENIP servers were never shut down properly. This is the commit I'm least happy with because the check in `handle_udp` feels somewhat hacky. But it mirrors the pre-existing check in `handle_tcp`, except it breaks out of the function entirely. The tests now wait for the greenlets to be done.
With these three fixes, the tests run and succeed without crashing. The `server.stop()`/`greenlet.join()` pattern in `tearDown()` should be repeated throughout the code, but as mentioned above a proper refactoring was too big for this PR. You don't want to copy&paste it everywhere because it's bound to be forgotten again. Some tests already have similar but not quite identical code.

1. The fourth commit improves ENIP test runtime and robustness: Tests were either hitting a timeout on success or **reporting success anyway**. That's why the ENIP test suite took >=12 seconds. It now takes just over 1 second on my machine AND `response` errors are no longer masked.