### PR TITLE
Fix test_docs being sensitive to current working directory

### DIFF
--- a/conpot/tests/test_docs.py
+++ b/conpot/tests/test_docs.py
@@ -15,9 +15,9 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-
-import unittest
+import os
 import subprocess
+import unittest
 
 
 class TestMakeDocs(unittest.TestCase):
@@ -30,6 +30,9 @@ class TestMakeDocs(unittest.TestCase):
 
     def test_make_docs(self):
         cmd = "make -C docs/ html"
-        process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+        project_root = os.path.join(os.path.dirname(__file__), "..", "..")
+
+        process = subprocess.Popen(cmd.split(), cwd=project_root, stdout=subprocess.PIPE)
         output = process.communicate()[0].decode()
+
         self.assertIn("Build finished. The HTML pages are in build/html.", output)


### PR DESCRIPTION
`test_make_docs` would invoke `make` with the relative paths from whichever was the current working directory as the tests were being run. This PR explicitly sets `cwd`. It really just adds one line and an `import`. The rest are whitespace changes and import sorting.

This way you can invoke this test individually, e.g. from an IDE, without manually setting the working directory.