### PR TITLE
Decouple Databus from SessionManager

### DIFF
--- a/bin/conpot
+++ b/bin/conpot
@@ -302,7 +302,7 @@ def main():
         sys.exit(1)
 
     session_manager = conpot_core.get_sessionManager()
-    session_manager.initialize_databus(template_base)
+    conpot_core.get_databus().initialize(template_base)
 
     # initialize the virtual file system
     fs_url = config.get('virtual_file_system', 'fs_url')

--- a/conpot/core/__init__.py
+++ b/conpot/core/__init__.py
@@ -14,12 +14,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from typing import Tuple, Union, Optional
 
+from .databus import Databus
+from .internal_interface import Interface
 from .session_manager import SessionManager
 from .virtual_fs import VirtualFS
-from typing import Tuple, Union, Optional
-from .internal_interface import Interface
 
+databus = Databus()
 sessionManager = SessionManager()
 virtualFS = VirtualFS()
 core_interface = Interface()
@@ -32,7 +34,7 @@ def get_sessionManager():
 
 
 def get_databus():
-    return sessionManager._databus
+    return databus
 
 
 def get_session(*args, **kwargs):

--- a/conpot/core/session_manager.py
+++ b/conpot/core/session_manager.py
@@ -18,14 +18,12 @@
 from gevent.queue import Queue
 
 from conpot.core.attack_session import AttackSession
-from conpot.core.databus import Databus
 
 
 # one instance only
 class SessionManager:
     def __init__(self):
         self._sessions = []
-        self._databus = Databus()
         self.log_queue = Queue()
 
     def _find_sessions(self, protocol, source_ip):
@@ -56,6 +54,3 @@ class SessionManager:
     def purge_sessions(self):
         # there is no native purge/clear mechanism for gevent queues, so...
         self.log_queue = Queue()
-
-    def initialize_databus(self, config_file):
-        self._databus.initialize(config_file)


### PR DESCRIPTION
This moves the `Databus` object out of the `SessionManager`. This allows future tests to instantiate `SessionManager`s without bothering with the databus.