### PR TITLE
Refactor greenlet handling and fix related bugs

### DIFF
--- a/bin/conpot
+++ b/bin/conpot
@@ -16,10 +16,9 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import gevent.monkey
+from gevent import monkey
 
-gevent.monkey.patch_all()
-
+monkey.patch_all()
 import logging
 import os
 import argparse
@@ -40,6 +39,7 @@ from conpot.core.loggers.log_worker import LogWorker
 from conpot.emulators.proxy import Proxy
 from conpot.helpers import fix_sslwrap
 from conpot.utils import ext_ip
+from conpot.utils.greenlet import spawn_startable_greenlet
 from conpot.utils import mac_addr
 
 logger = logging.getLogger()
@@ -421,9 +421,9 @@ def main():
                         server = server_class(
                             protocol_template, root_template_directory, args
                         )
-                        greenlet = gevent.spawn(server.start, host, port)
+                        greenlet = spawn_startable_greenlet(server, host, port)
                         greenlet.link_exception(on_unhandled_greenlet_exception)
-                        servers.append(server)
+                        servers.append((server, greenlet))
                         logger.info(
                             "Found and enabled {} protocol.".format(
                                 protocol_name, server
@@ -443,8 +443,9 @@ def main():
                 )
 
         log_worker = LogWorker(config, dom_base, session_manager, public_ip)
-        greenlet = gevent.spawn(log_worker.start)
+        greenlet = spawn_startable_greenlet(log_worker)
         greenlet.link_exception(on_unhandled_greenlet_exception)
+        servers.append((log_worker, greenlet))
 
         # TODO: Line up Proxy init with other protocols
         template_proxy = os.path.join(root_template_directory, "proxy", "proxy.xml")
@@ -492,24 +493,25 @@ def main():
                             name, proxy_host, proxy_port, decoder, keyfile, certfile
                         )
                         proxy_server = proxy_instance.get_server(host, port)
-                        servers.append(proxy_instance)
-                        proxy_greenlet = gevent.spawn(proxy_server.start)
+                        proxy_greenlet = spawn_startable_greenlet(proxy_server)
                         proxy_greenlet.link_exception(on_unhandled_greenlet_exception)
+                        servers.append((proxy_instance, proxy_greenlet))
                 else:
                     logger.info("Proxy available but disabled by template.")
         else:
             logger.info(
                 "No proxy template found. Service will remain unconfigured/stopped."
             )
-        # Wait for the services to bind ports before forking
-        gevent.sleep(5)
+
         try:
             if len(servers) > 0:
                 gevent.wait()
         except KeyboardInterrupt:
             logging.info("Stopping Conpot")
-            for server in servers:
+            for server, greenlet in servers:
+                logging.debug(f"Shutting down {greenlet.name}")
                 server.stop()
+                greenlet.get()
         finally:
             conpot_core.close_fs()
 

--- a/bin/conpot
+++ b/bin/conpot
@@ -29,29 +29,16 @@ import grp
 import ast
 import inspect
 from configparser import ConfigParser, NoSectionError, NoOptionError
+
 import gevent
 from lxml import etree
+
 import conpot
 import conpot.core as conpot_core
+from conpot import protocols
 from conpot.core.loggers.log_worker import LogWorker
-from conpot.protocols.snmp.snmp_server import SNMPServer
-from conpot.protocols.modbus.modbus_server import ModbusServer
-from conpot.protocols.s7comm.s7_server import S7Server
-from conpot.protocols.http.web_server import HTTPServer
-from conpot.protocols.enip.enip_server import EnipServer
-from conpot.helpers import fix_sslwrap
-from conpot.protocols.kamstrup.meter_protocol.kamstrup_server import KamstrupServer
-from conpot.protocols.kamstrup.management_protocol.kamstrup_management_server import (
-    KamstrupManagementServer,
-)
-from conpot.protocols.bacnet.bacnet_server import BacnetServer
-from conpot.protocols.ipmi.ipmi_server import IpmiServer
-from conpot.protocols.guardian_ast.guardian_ast_server import GuardianASTServer
-from conpot.protocols.IEC104.IEC104_server import IEC104Server
-from conpot.protocols.ftp.ftp_server import FTPServer
-from conpot.protocols.tftp.tftp_server import TftpServer
-
 from conpot.emulators.proxy import Proxy
+from conpot.helpers import fix_sslwrap
 from conpot.utils import ext_ip
 from conpot.utils import mac_addr
 
@@ -381,21 +368,6 @@ def main():
             mac_addr.change_mac(config=config)
         else:
             logger.info("Changing mac address require sudo permissions. Skipping")
-    protocol_instance_mapping = (
-        ("modbus", ModbusServer),
-        ("s7comm", S7Server),
-        ("kamstrup_meter", KamstrupServer),
-        ("kamstrup_management", KamstrupManagementServer),
-        ("http", HTTPServer),
-        ("snmp", SNMPServer),
-        ("bacnet", BacnetServer),
-        ("ipmi", IpmiServer),
-        ("guardian_ast", GuardianASTServer),
-        ("enip", EnipServer),
-        ("IEC104", IEC104Server),
-        ("ftp", FTPServer),
-        ("tftp", TftpServer),
-    )
 
     # no need to fork process when we don't want to change MAC address
     pid = 0
@@ -403,8 +375,7 @@ def main():
         pid = gevent.fork()
 
     if pid == 0:
-        for protocol in protocol_instance_mapping:
-            protocol_name, server_class = protocol
+        for protocol_name, server_class in protocols.name_mapping.items():
             protocol_template = os.path.join(
                 root_template_directory, protocol_name, "{0}.xml".format(protocol_name)
             )
@@ -454,7 +425,9 @@ def main():
                         greenlet.link_exception(on_unhandled_greenlet_exception)
                         servers.append(server)
                         logger.info(
-                            "Found and enabled {} protocol.".format(protocol[0])
+                            "Found and enabled {} protocol.".format(
+                                protocol_name, server
+                            )
                         )
                 else:
                     logger.info(
@@ -473,7 +446,7 @@ def main():
         greenlet = gevent.spawn(log_worker.start)
         greenlet.link_exception(on_unhandled_greenlet_exception)
 
-        # TODO: Make proxy fit into protocol_instance_mapping
+        # TODO: Line up Proxy init with other protocols
         template_proxy = os.path.join(root_template_directory, "proxy", "proxy.xml")
         if os.path.isfile(template_proxy):
             xsd_file = os.path.join(

--- a/bin/start_protocol.py
+++ b/bin/start_protocol.py
@@ -1,0 +1,76 @@
+# Copyright (C) 2020  srenfo
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+import sys
+from types import SimpleNamespace
+
+import gevent
+
+from conpot import protocols
+from conpot.core import initialize_vfs
+from conpot.utils.greenlet import spawn_test_server, teardown_test_server
+
+
+def _init_test_server_by_name(name, port=0):
+    server_class = protocols.name_mapping[name]
+
+    template = {
+        "guardian_ast": "guardian_ast",
+        "IEC104": "IEC104",
+        "kamstrup_management": "kamstrup_382",
+        "kamstrup_meter": "kamstrup_382",
+    }.get(name, "default")
+
+    # Required by SNMP
+    class Args(SimpleNamespace):
+        mibcache = None
+
+    if name in ("ftp", "tftp"):
+        initialize_vfs()
+
+    return spawn_test_server(server_class, template, name, args=Args(), port=port)
+
+
+def main():
+    """Start individual protocol instances (for debugging)"""
+    name = sys.argv[1]
+
+    ports = {
+        "bacnet": 9999,
+        "enip": 60002,
+        "ftp": 10001,
+        "guardian_ast": 10001,
+        "http": 50001,
+        "kamstrup_management": 50100,
+        "kamstrup_meter": 1025,
+        "ipmi": 10002,
+        "s7comm": 9999,
+        "tftp": 6090,
+    }
+
+    port = ports.get(name, 0)
+
+    print(f"Starting '{name}'...")
+    server, greenlet = _init_test_server_by_name(name, port=port)
+
+    try:
+        gevent.wait()
+    except KeyboardInterrupt:
+        teardown_test_server(server=server, greenlet=greenlet)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/start_protocol.py
+++ b/bin/start_protocol.py
@@ -15,33 +15,10 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 import sys
-from types import SimpleNamespace
 
 import gevent
 
-from conpot import protocols
-from conpot.core import initialize_vfs
-from conpot.utils.greenlet import spawn_test_server, teardown_test_server
-
-
-def _init_test_server_by_name(name, port=0):
-    server_class = protocols.name_mapping[name]
-
-    template = {
-        "guardian_ast": "guardian_ast",
-        "IEC104": "IEC104",
-        "kamstrup_management": "kamstrup_382",
-        "kamstrup_meter": "kamstrup_382",
-    }.get(name, "default")
-
-    # Required by SNMP
-    class Args(SimpleNamespace):
-        mibcache = None
-
-    if name in ("ftp", "tftp"):
-        initialize_vfs()
-
-    return spawn_test_server(server_class, template, name, args=Args(), port=port)
+from conpot.utils.greenlet import init_test_server_by_name, teardown_test_server
 
 
 def main():
@@ -64,7 +41,7 @@ def main():
     port = ports.get(name, 0)
 
     print(f"Starting '{name}'...")
-    server, greenlet = _init_test_server_by_name(name, port=port)
+    server, greenlet = init_test_server_by_name(name, port=port)
 
     try:
         gevent.wait()

--- a/conpot/core/protocol_wrapper.py
+++ b/conpot/core/protocol_wrapper.py
@@ -32,6 +32,8 @@ def conpot_protocol(cls):
 
                 core_interface.protocols[self.cls].append(self.wrapped)
 
+            self.__class__.__name__ = self.cls.__name__
+
         def __getattr__(self, name):
             if name == "handle":
                 # assuming that handle function from a class is only called when a client tries to connect with an
@@ -45,8 +47,7 @@ def conpot_protocol(cls):
         def __repr__(self):
             return self.wrapped.__repr__()
 
-        __doc__ = property(lambda self: self.cls.__doc__)
-        __module__ = property(lambda self: self.cls.__module__)
-        __name__ = property(lambda self: self.cls.__name__)
+        __doc__ = cls.__doc__
+        __module__ = cls.__module__
 
     return Wrapper

--- a/conpot/protocols/IEC104/IEC104_server.py
+++ b/conpot/protocols/IEC104/IEC104_server.py
@@ -147,7 +147,7 @@ class IEC104Server(object):
         connection = (host, port)
         self.server = StreamServer(connection, self.handle)
         logger.info("IEC 60870-5-104 protocol server started on: %s", connection)
-        self.server.start()
+        self.server.serve_forever()
 
     def stop(self):
         self.server.stop()

--- a/conpot/protocols/__init__.py
+++ b/conpot/protocols/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2020  srenfo
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+from .IEC104.IEC104_server import IEC104Server
+from .bacnet.bacnet_server import BacnetServer
+from .enip.enip_server import EnipServer
+from .ftp.ftp_server import FTPServer
+from .guardian_ast.guardian_ast_server import GuardianASTServer
+from .http.web_server import HTTPServer
+from .ipmi.ipmi_server import IpmiServer
+from .kamstrup.management_protocol.kamstrup_management_server import (
+    KamstrupManagementServer,
+)
+from .kamstrup.meter_protocol.kamstrup_server import KamstrupServer
+from .modbus.modbus_server import ModbusServer
+from .s7comm.s7_server import S7Server
+from .snmp.snmp_server import SNMPServer
+from .tftp.tftp_server import TftpServer
+
+
+# Defines protocol directory names inside template directories
+name_mapping = {
+    "bacnet": BacnetServer,
+    "enip": EnipServer,
+    "ftp": FTPServer,
+    "guardian_ast": GuardianASTServer,
+    "http": HTTPServer,
+    "IEC104": IEC104Server,
+    "ipmi": IpmiServer,
+    "kamstrup_management": KamstrupManagementServer,
+    "kamstrup_meter": KamstrupServer,
+    "modbus": ModbusServer,
+    "s7comm": S7Server,
+    "snmp": SNMPServer,
+    "tftp": TftpServer,
+}

--- a/conpot/protocols/bacnet/bacnet_server.py
+++ b/conpot/protocols/bacnet/bacnet_server.py
@@ -89,13 +89,13 @@ class BacnetServer(object):
         )
 
     def start(self, host, port):
-        self.host = host
-        self.port = port
         connection = (host, port)
         self.server = DatagramServer(connection, self.handle)
         # start to init the socket
         self.server.start()
         self.server.socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self.host = self.server.server_host
+        self.port = self.server.server_port
         # create application instance
         # not too beautiful, but the BACnetApp needs access to the socket's sendto method
         # this could properly be refactored in a way such that sending operates on it's own
@@ -104,7 +104,7 @@ class BacnetServer(object):
         # get object_list and properties
         self.bacnet_app.get_objects_and_properties(self.dom)
 
-        logger.info("Bacnet server started on: %s", connection)
+        logger.info("Bacnet server started on: %s", (self.host, self.port))
         self.server.serve_forever()
 
     def stop(self):

--- a/conpot/protocols/bacnet/bacnet_server.py
+++ b/conpot/protocols/bacnet/bacnet_server.py
@@ -18,11 +18,6 @@
 # Author: Peter Sooky <xsooky00@stud.fit.vubtr.cz>
 # Brno University of Technology, Faculty of Information Technology
 
-import gevent
-from gevent import monkey
-
-gevent.monkey.patch_all()
-
 import socket
 from lxml import etree
 from gevent.server import DatagramServer
@@ -114,43 +109,3 @@ class BacnetServer(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    import os
-
-    test_template = os.getcwd() + "/../../templates/default/bacnet/bacnet.xml"
-    test = BacnetServer(test_template, None, None)
-    try:
-        from bacpypes.apdu import WhoIsRequest, WhoHasObject, WhoHasRequest
-
-        # code for generating adpu - who-is
-        # request = WhoIsRequest(deviceInstanceRangeLowLimit=500, deviceInstanceRangeHighLimit=50000)
-        # test_pdu = PDU()
-        # test_apdu = APDU()
-        # request.encode(test_apdu)
-        # test_apdu.encode(test_pdu)
-        # bacnet_app = BACnetApp(test.thisDevice, test)
-        # bacnet_app.get_objects_and_properties(test.dom)
-        # bacnet_app.indication(test_apdu, ('127.0.0.1', 9999), test.thisDevice)
-        # print(bacnet_app._response)
-        # bacnet_app.response(bacnet_app._response, ('127.0.0.1', 9999))
-        # # logger.debug('Starting BACnet Server! at {}:{}'.format('localhost', 9999))
-        # # test.start('127.0.0.1', 9999)
-
-        # testing who-has
-        request_object = WhoHasObject()
-        request_object.objectIdentifier = ("binaryInput", 12)
-        request = WhoHasRequest(object=request_object)
-        test_apdu = APDU()
-        request.encode(test_apdu)
-        test_pdu = PDU()
-        test_apdu.encode(test_pdu)
-        bacnet_app = BACnetApp(test.thisDevice, test)
-        bacnet_app.get_objects_and_properties(test.dom)
-        bacnet_app.indication(test_apdu, ("127.0.0.1", 9999), test.thisDevice)
-        print(bacnet_app._response)
-        bacnet_app.response(bacnet_app._response, ("127.0.0.1", 9999))
-    except KeyboardInterrupt:
-        logger.debug("Stopping BACnet server")
-        test.stop()

--- a/conpot/protocols/enip/enip_server.py
+++ b/conpot/protocols/enip/enip_server.py
@@ -631,17 +631,3 @@ class EnipServer(object):
         logger.debug("Stopping ENIP server")
         self.control["done"] = True
         self.start_event.clear()
-
-
-if __name__ == "__main__":
-    import conpot, os
-
-    dir_name = os.path.dirname(conpot.__file__)
-    template = dir_name + "/templates/default/enip/enip.xml"
-    enip_server_implicit = EnipServer(template, None, None)
-    enip_server_implicit.config.mode = "udp"
-    enip_server_implicit.port = 60002
-    try:
-        enip_server_implicit.start(enip_server_implicit.addr, enip_server_implicit.port)
-    except KeyboardInterrupt:
-        enip_server_implicit.stop()

--- a/conpot/protocols/enip/enip_server.py
+++ b/conpot/protocols/enip/enip_server.py
@@ -23,7 +23,6 @@ import time
 import sys
 import traceback
 
-from gevent.event import Event
 from lxml import etree
 from cpppo.server import network
 from cpppo.server.enip import logix
@@ -100,7 +99,6 @@ class EnipServer(object):
         self.port = self.config.server_port
         self.connections = cpppo.dotdict()
         self.control = None
-        self.start_event = Event()
 
         # all known tags
         self.tags = cpppo.dotdict()
@@ -613,7 +611,6 @@ class EnipServer(object):
         udp_mode = True if self.config.mode == "udp" else False
 
         self.control = srv_ctl.control
-        self.start_event.set()
 
         logger.debug(
             "ENIP server started on: %s:%d, mode: %s" % (host, port, self.config.mode)
@@ -630,4 +627,3 @@ class EnipServer(object):
     def stop(self):
         logger.debug("Stopping ENIP server")
         self.control["done"] = True
-        self.start_event.clear()

--- a/conpot/protocols/ftp/ftp_base_handler.py
+++ b/conpot/protocols/ftp/ftp_base_handler.py
@@ -15,9 +15,6 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from gevent import monkey
-
-monkey.patch_all()
 import socketserver
 import gevent
 from gevent import queue

--- a/conpot/protocols/ftp/ftp_server.py
+++ b/conpot/protocols/ftp/ftp_server.py
@@ -26,9 +26,6 @@ from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)
-# import sys
-# import logging as logger
-# logger.basicConfig(stream=sys.stdout, level=logger.DEBUG)
 
 
 class FTPConfig(object):
@@ -315,19 +312,3 @@ class FTPServer(object):
         logger.debug("Stopping FTP server")
         self.server.stop()
         del self.handler
-
-
-# ---- For debugging ----
-if __name__ == "__main__":
-    # Set vars for connection information
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 10001
-    import os
-
-    conpot_core.initialize_vfs()
-    test_template = os.getcwd() + "/../../templates/default/ftp/ftp.xml"
-    server = FTPServer(test_template, None, None)
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/guardian_ast/guardian_ast_server.py
+++ b/conpot/protocols/guardian_ast/guardian_ast_server.py
@@ -510,8 +510,6 @@ class GuardianASTServer(object):
         session.add_event({"type": "CONNECTION_LOST"})
 
     def start(self, host, port):
-        self.host = host
-        self.port = port
         connection = (host, port)
         self.server = StreamServer(connection, self.handle)
         logger.info("GuardianAST server started on: {0}".format(connection))

--- a/conpot/protocols/guardian_ast/guardian_ast_server.py
+++ b/conpot/protocols/guardian_ast/guardian_ast_server.py
@@ -22,13 +22,11 @@ Original authors: Kyle Wilhoit and Stephen Hilt
 
 from gevent.server import StreamServer
 import datetime
+import logging
 import random
-import conpot
 import conpot.core as conpot_core
 from conpot.core.protocol_wrapper import conpot_protocol
 from conpot.helpers import str_to_bytes
-
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -521,18 +519,3 @@ class GuardianASTServer(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    # Set vars for connection information
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 10001
-    import os
-
-    dir_name = os.path.dirname(conpot.__file__)
-    server = GuardianASTServer(None, None, None)
-    server.databus.initialize(dir_name + "/templates/guardian_ast/template.xml")
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/http/web_server.py
+++ b/conpot/protocols/http/web_server.py
@@ -43,23 +43,3 @@ class HTTPServer(object):
     def stop(self):
         if self.cmd_responder:
             self.cmd_responder.stop()
-
-
-if __name__ == "__main__":
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 50001
-    import os
-    import conpot
-    import conpot.core as conpot_core
-
-    dir_name = os.path.dirname(conpot.__file__)
-    conpot_core.get_databus().initialize(dir_name + "/templates/default/template.xml")
-    server = HTTPServer(
-        dir_name + "/templates/default/http/http.xml",
-        dir_name + "/templates/default/",
-        None,
-    )
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/ipmi/ipmi_server.py
+++ b/conpot/protocols/ipmi/ipmi_server.py
@@ -24,20 +24,13 @@ import uuid
 import hmac
 import hashlib
 import os
-from os import urandom
 from conpot.helpers import chr_py3
 import collections
 from lxml import etree
 from conpot.protocols.ipmi.fakebmc import FakeBmc
 from conpot.protocols.ipmi.fakesession import FakeSession
-import sys
 import conpot.core as conpot_core
-
-# import logging
-# logger = logging.getLogger(__name__)
 import logging as logger
-
-logger.basicConfig(stream=sys.stdout, level=logger.DEBUG)
 
 
 class IpmiServer(object):
@@ -537,22 +530,3 @@ class IpmiServer(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 10002
-    import os
-    import conpot
-
-    dir_name = os.path.dirname(conpot.__file__)
-    conpot_core.get_databus().initialize(dir_name + "/templates/default/template.xml")
-    server = IpmiServer(
-        dir_name + "/templates/default/ipmi/ipmi.xml",
-        dir_name + "/templates/default/",
-        None,
-    )
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/kamstrup/management_protocol/kamstrup_management_server.py
+++ b/conpot/protocols/kamstrup/management_protocol/kamstrup_management_server.py
@@ -18,7 +18,6 @@ import socket
 
 import gevent
 from gevent.server import StreamServer
-import conpot
 import conpot.core as conpot_core
 from conpot.protocols.kamstrup.management_protocol.command_responder import (
     CommandResponder,
@@ -106,24 +105,3 @@ class KamstrupManagementServer(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 50100
-    import os
-
-    dir_name = os.path.dirname(conpot.__file__)
-    conpot_core.get_databus().initialize(
-        dir_name + "/templates/kamstrup_382/template.xml"
-    )
-    server = KamstrupManagementServer(
-        dir_name
-        + "/templates/kamstrup_382/kamstrup_management/kamstrup_management.xml",
-        None,
-        None,
-    )
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/kamstrup/meter_protocol/kamstrup_server.py
+++ b/conpot/protocols/kamstrup/meter_protocol/kamstrup_server.py
@@ -15,10 +15,10 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import socket
 import binascii
+import logging
 import random
-import conpot
+import socket
 from gevent.server import StreamServer
 import gevent
 from conpot.helpers import chr_py3
@@ -26,11 +26,6 @@ import conpot.core as conpot_core
 from conpot.protocols.kamstrup.meter_protocol import request_parser
 from conpot.protocols.kamstrup.meter_protocol.command_responder import CommandResponder
 from conpot.core.protocol_wrapper import conpot_protocol
-
-# import logging as logger
-# import sys
-# logger.basicConfig(stream=sys.stdout, level=logger.DEBUG)
-import logging
 
 logger = logging.getLogger(__name__)
 
@@ -132,23 +127,3 @@ class KamstrupServer(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    TCP_IP = "127.0.0.1"
-    TCP_PORT = 1025
-    import os
-
-    dir_name = os.path.dirname(conpot.__file__)
-    conpot_core.get_databus().initialize(
-        dir_name + "/templates/kamstrup_382/template.xml"
-    )
-    server = KamstrupServer(
-        dir_name + "/templates/kamstrup_382/kamstrup_meter/kamstrup_meter.xml",
-        None,
-        None,
-    )
-    try:
-        server.start(TCP_IP, TCP_PORT)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/protocols/modbus/modbus_server.py
+++ b/conpot/protocols/modbus/modbus_server.py
@@ -24,12 +24,13 @@ logger = logging.getLogger(__name__)
 @conpot_protocol
 class ModbusServer(modbus.Server):
     def __init__(self, template, template_directory, args, timeout=5):
-
         self.timeout = timeout
         self.delay = None
         self.mode = None
         self.host = None
         self.port = None
+        self.server = None
+
         databank = slave_db.SlaveBase(template)
 
         # Constructor: initializes the server settings
@@ -190,6 +191,9 @@ class ModbusServer(modbus.Server):
         self.host = host
         self.port = port
         connection = (host, port)
-        server = StreamServer(connection, self.handle)
+        self.server = StreamServer(connection, self.handle)
         logger.info("Modbus server started on: %s", connection)
-        server.start()
+        self.server.serve_forever()
+
+    def stop(self):
+        self.server.stop()

--- a/conpot/protocols/s7comm/s7_server.py
+++ b/conpot/protocols/s7comm/s7_server.py
@@ -311,14 +311,3 @@ class S7Server(object):
 
     def stop(self):
         self.server.stop()
-
-
-if __name__ == "__main__":
-    import os
-
-    test_template = os.getcwd() + "/../../templates/default/s7comm/s7comm.xml"
-    test = S7Server(test_template, None, None)
-    try:
-        test.start("127.0.0.1", 9999)
-    except KeyboardInterrupt:
-        test.stop()

--- a/conpot/protocols/snmp/command_responder.py
+++ b/conpot/protocols/snmp/command_responder.py
@@ -209,4 +209,4 @@ class CommandResponder(object):
         self.snmpEngine.transportDispatcher.serve_forever()
 
     def stop(self):
-        self.snmpEngine.transportDispatcher.stop_accepting()
+        self.snmpEngine.transportDispatcher.stop()

--- a/conpot/protocols/tftp/tftp_handler.py
+++ b/conpot/protocols/tftp/tftp_handler.py
@@ -1,6 +1,3 @@
-from gevent import monkey
-
-monkey.patch_all()
 import fs
 import os
 import logging

--- a/conpot/protocols/tftp/tftp_server.py
+++ b/conpot/protocols/tftp/tftp_server.py
@@ -20,9 +20,6 @@
 
 import gevent
 import os
-from gevent import monkey
-
-gevent.monkey.patch_all()
 from lxml import etree
 from conpot.protocols.tftp import tftp_handler
 from gevent.server import DatagramServer
@@ -31,14 +28,9 @@ from conpot.core.protocol_wrapper import conpot_protocol
 from gevent import event
 from tftpy import TftpException, TftpTimeout
 import logging
-
-logger = logging.getLogger(__name__)
 from conpot.utils.ext_ip import get_interface_ip
 
-# For debugging --
-# import logging as logger
-# import sys
-# logger.basicConfig(stream=sys.stdout, level=logger.DEBUG)
+logger = logging.getLogger(__name__)
 
 
 @conpot_protocol
@@ -189,21 +181,3 @@ class TftpServer(object):
 
     def stop(self):
         self.server.close()
-
-
-if __name__ == "__main__":
-    import conpot
-
-    # initialize the file system.
-    conpot_core.initialize_vfs()
-    # get the current directory
-    dir_name = os.path.dirname(conpot.__file__)
-    server = TftpServer(
-        dir_name + "/templates/default/tftp/tftp.xml",
-        dir_name + "/templates/default",
-        args=None,
-    )
-    try:
-        server.start("127.0.0.1", 6090)
-    except KeyboardInterrupt:
-        server.stop()

--- a/conpot/tests/test_bacnet_server.py
+++ b/conpot/tests/test_bacnet_server.py
@@ -15,18 +15,13 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import gevent
 from gevent import monkey
 
-gevent.monkey.patch_all()
+monkey.patch_all()
 
 import unittest
-from gevent import socket
-import os
-import conpot
-import conpot.core as conpot_core
-from conpot.protocols.bacnet import bacnet_server
-from collections import namedtuple
+from gevent import socket, Timeout
+
 from bacpypes.pdu import GlobalBroadcast, PDU
 from bacpypes.apdu import (
     APDU,
@@ -43,6 +38,9 @@ from bacpypes.apdu import (
 from bacpypes.constructeddata import Any
 from bacpypes.primitivedata import Real
 
+from conpot.protocols.bacnet import bacnet_server
+from conpot.utils.greenlet import spawn_test_server, teardown_test_server
+
 
 class TestBACnetServer(unittest.TestCase):
 
@@ -53,26 +51,14 @@ class TestBACnetServer(unittest.TestCase):
     """
 
     def setUp(self):
-        # clean up before we start...
-        conpot_core.get_sessionManager().purge_sessions()
-
-        # get the current directory
-        self.dir_name = os.path.dirname(conpot.__file__)
-        args = namedtuple("FakeArgs", "")
-        self.bacnet_server = bacnet_server.BacnetServer(
-            self.dir_name + "/templates/default/bacnet/bacnet.xml", "none", args
+        self.bacnet_server, self.greenlet = spawn_test_server(
+            bacnet_server.BacnetServer, "default", "bacnet"
         )
-        self.server_greenlet = gevent.spawn(self.bacnet_server.start, "127.0.0.1", 0)
-        gevent.sleep(1)
-        # initialize the databus
-        self.databus = conpot_core.get_databus()
-        self.databus.initialize(self.dir_name + "/templates/default/template.xml")
+
+        self.address = (self.bacnet_server.host, self.bacnet_server.port)
 
     def tearDown(self):
-        self.bacnet_server.stop()
-        gevent.joinall([self.server_greenlet])
-        # tidy up (again)...
-        conpot_core.get_sessionManager().purge_sessions()
+        teardown_test_server(self.bacnet_server, self.greenlet)
 
     def test_whoIs(self):
         request = WhoIsRequest(
@@ -84,7 +70,7 @@ class TestBACnetServer(unittest.TestCase):
         apdu.encode(pdu)
         buf_size = 1024
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.sendto(pdu.pduData, ("127.0.0.1", self.bacnet_server.server.server_port))
+        s.sendto(pdu.pduData, self.address)
         data = s.recvfrom(buf_size)
         s.close()
         received_data = data[0]
@@ -113,7 +99,7 @@ class TestBACnetServer(unittest.TestCase):
         apdu.encode(pdu)
         buf_size = 1024
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.sendto(pdu.pduData, ("127.0.0.1", self.bacnet_server.server.server_port))
+        s.sendto(pdu.pduData, self.address)
         data = s.recvfrom(buf_size)
         s.close()
         received_data = data[0]
@@ -131,7 +117,6 @@ class TestBACnetServer(unittest.TestCase):
         self.assertEqual(exp_pdu.pduData, received_data)
 
     def test_readProperty(self):
-
         request = ReadPropertyRequest(
             objectIdentifier=("analogInput", 14), propertyIdentifier=85
         )
@@ -143,7 +128,7 @@ class TestBACnetServer(unittest.TestCase):
         apdu.encode(pdu)
         buf_size = 1024
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.sendto(pdu.pduData, ("127.0.0.1", self.bacnet_server.server.server_port))
+        s.sendto(pdu.pduData, self.address)
         data = s.recvfrom(buf_size)
         s.close()
         received_data = data[0]
@@ -198,12 +183,9 @@ class TestBACnetServer(unittest.TestCase):
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         buf_size = 1024
-        [
-            s.sendto(i.pduData, ("127.0.0.1", self.bacnet_server.server.server_port))
-            for i in test_requests
-        ]
+        [s.sendto(i.pduData, self.address) for i in test_requests]
         results = None
-        with gevent.Timeout(1, False):
+        with Timeout(1, False):
             results = [s.recvfrom(buf_size) for i in range(len(test_requests))]
         self.assertIsNone(results)
 

--- a/conpot/tests/test_greenlet.py
+++ b/conpot/tests/test_greenlet.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2020  srenfo
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from contextlib import redirect_stderr
+
+import pytest
+from gevent import Greenlet, sleep
+
+from conpot import core
+from conpot.utils.greenlet import (
+    spawn_startable_greenlet,
+    spawn_test_server,
+    teardown_test_server,
+)
+
+
+class StartableStub:
+    def __init__(self):
+        self.args = None
+
+    def start(self, *args):
+        self.args = args
+
+
+@pytest.mark.parametrize("args", ((), ("127.0.0.1", 8080), (1, 2, 3, 4)))
+def test_spawn_startable_greenlet_passes_args(args):
+    instance = StartableStub()
+
+    greenlet = spawn_startable_greenlet(instance, *args)
+    greenlet.get()
+
+    assert instance.args == args
+
+
+def test_spawn_startable_greenlet_sets_name():
+    greenlet = spawn_startable_greenlet(StartableStub())
+
+    assert str(greenlet).startswith('<ServiceGreenlet "StartableStub"')
+
+
+def test_spawn_startable_greenlet_not_scheduled():
+    greenlet = spawn_startable_greenlet(StartableStub())
+
+    assert not greenlet.scheduled_once.is_set()
+
+
+def test_spawn_startable_greenlet_can_observe_scheduling():
+    greenlet = spawn_startable_greenlet(StartableStub())
+    greenlet.scheduled_once.wait()
+
+    assert greenlet.scheduled_once.is_set()
+
+
+class ServerStub:
+    def __init__(self, template, template_directory, args):
+        self.template = template
+        self.template_directory = template_directory
+        self.args = args
+        self.host = None
+        self.port = None
+
+    def start(self, host, port):
+        self.host = host
+        self.port = port
+
+
+def test_spawn_test_server_returns_server_and_greenlet():
+    server, greenlet = spawn_test_server(
+        ServerStub, "default", "Fake", args="arbitrary"
+    )
+
+    assert isinstance(server, ServerStub)
+    assert isinstance(greenlet, Greenlet)
+
+    assert server.template.endswith("/conpot/templates/default/Fake/Fake.xml")
+    assert server.template_directory.endswith("/conpot/templates/default")
+    assert server.args == "arbitrary"
+
+
+def test_spawn_test_server_initializes_databus():
+    spawn_test_server(ServerStub, "default", "Fake")
+
+    assert core.get_databus().initialized.is_set()
+
+
+def test_spawn_test_server_runs_at_least_once():
+    _, greenlet = spawn_test_server(ServerStub, "default", "Fake")
+
+    assert greenlet.scheduled_once.is_set()
+
+
+def test_spawn_test_server_starts_on_localhost_any_port():
+    server, _ = spawn_test_server(ServerStub, "default", "Fake")
+
+    assert server.host == "127.0.0.1"
+    assert server.port == 0
+
+
+def test_spawn_test_server_can_set_port():
+    server, _ = spawn_test_server(ServerStub, "default", "Fake", port=42)
+
+    assert server.port == 42
+
+
+class LoopingServer:
+    def __init__(self, *_, **__):
+        self.stopped = False
+
+    def start(self, _, __):
+        while not self.stopped:
+            sleep()
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_teardown_test_server_stops_instance():
+    server, greenlet = spawn_test_server(LoopingServer, "default", "Fake")
+
+    teardown_test_server(server, greenlet)
+
+    assert server.stopped
+    assert greenlet.dead
+
+
+class RaisingServer(LoopingServer):
+    def start(self, host, port):
+        super().start(host, port)
+        raise RuntimeError("Test Error")
+
+
+def test_teardown_test_server_propagates_exception():
+    server, greenlet = spawn_test_server(RaisingServer, "default", "Fake")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        # Greenlets print exception tracebacks to stderr, suppress that in this test
+        with redirect_stderr(None):
+            teardown_test_server(server, greenlet)
+
+    assert str(exc_info.value) == "Test Error"

--- a/conpot/tests/test_protocol_wrapper.py
+++ b/conpot/tests/test_protocol_wrapper.py
@@ -3,6 +3,8 @@ from conpot.core.protocol_wrapper import conpot_protocol
 
 @conpot_protocol
 class ProtocolFake:
+    """Fake docstring"""
+
     def __init__(self, value):
         self.value = value
 
@@ -24,3 +26,9 @@ def test_instances_have_separate_repr():
 
     assert repr(inst_1) == "ProtocolFake(1)"
     assert repr(inst_2) == "ProtocolFake(2)"
+
+
+def test_wrapped_classes_have_inner_class_attributes():
+    assert ProtocolFake.__doc__ == "Fake docstring"
+    assert ProtocolFake.__module__ == __name__
+    assert ProtocolFake.__name__ == "ProtocolFake"

--- a/conpot/tests/test_protocols.py
+++ b/conpot/tests/test_protocols.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2020  srenfo
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import pytest
+
+from conpot import protocols
+from conpot.utils.greenlet import init_test_server_by_name
+
+
+@pytest.mark.parametrize("name", protocols.name_mapping.keys())
+def test_protocols_can_be_stopped(name):
+    server, greenlet = init_test_server_by_name(name)
+
+    server.stop()
+    greenlet.join(0.2)
+
+    # Greenlets with working shutdown logic will have run to completion
+    # Greenlets with broken shutdown logic will wait to be scheduled again
+    assert greenlet.successful()
+
+
+@pytest.mark.parametrize("name", protocols.name_mapping.keys())
+def test_protocols_serve_forever(name):
+    server, greenlet = init_test_server_by_name(name)
+
+    assert not greenlet.ready()
+
+    server.stop()
+    greenlet.join(0.2)

--- a/conpot/tests/test_s7_server.py
+++ b/conpot/tests/test_s7_server.py
@@ -15,34 +15,26 @@
 # Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import gevent.monkey
+from gevent import monkey
 
-gevent.monkey.patch_all()
-import os
+monkey.patch_all()
 import unittest
-from collections import namedtuple
-import conpot
 from conpot.protocols.s7comm.s7_server import S7Server
 from conpot.tests.helpers import s7comm_client
-
-import conpot.core as conpot_core
+from conpot.utils.greenlet import spawn_test_server, teardown_test_server
 
 
 class TestS7Server(unittest.TestCase):
     def setUp(self):
-        self.databus = conpot_core.get_databus()
-        self.dir_name = os.path.dirname(conpot.__file__)
-        self.databus.initialize(self.dir_name + "/templates/default/template.xml")
-        args = namedtuple("FakeArgs", "")
-        self.s7_instance = S7Server(
-            self.dir_name + "/templates/default/s7comm/s7comm.xml", "none", args
+        self.s7_instance, self.greenlet = spawn_test_server(
+            S7Server, "default", "s7comm"
         )
-        gevent.spawn(self.s7_instance.start, "127.0.0.1", 0)
-        gevent.sleep(0.5)
+
+        self.server_host = self.s7_instance.server.server_host
         self.server_port = self.s7_instance.server.server_port
 
     def tearDown(self):
-        self.s7_instance.stop()
+        teardown_test_server(self.s7_instance, self.greenlet)
 
     def test_s7(self):
         """
@@ -50,7 +42,7 @@ class TestS7Server(unittest.TestCase):
         """
         src_tsaps = (0x100, 0x200)
         dst_tsaps = (0x102, 0x200, 0x201)
-        s7_con = s7comm_client.s7("127.0.0.1", self.server_port)
+        s7_con = s7comm_client.s7(self.server_host, self.server_port)
         res = None
         for src_tsap in src_tsaps:
             for dst_tsap in dst_tsaps:
@@ -68,7 +60,7 @@ class TestS7Server(unittest.TestCase):
         s7_con.s.connect((s7_con.ip, s7_con.port))
         s7_con.Connect()
         identities = s7comm_client.GetIdentity(
-            "127.0.0.1", self.server_port, res[0], res[1]
+            self.server_host, self.server_port, res[0], res[1]
         )
         s7_con.plc_stop_function()
 

--- a/conpot/tests/test_tftp.py
+++ b/conpot/tests/test_tftp.py
@@ -1,40 +1,36 @@
-import os
 import unittest
-import conpot
-import gevent
-import tftpy
 import filecmp
-import conpot.core as conpot_core
 from freezegun import freeze_time
+from tftpy import TftpClient
+
+import conpot
+import conpot.core as conpot_core
 from conpot.protocols.tftp.tftp_server import TftpServer
+from conpot.utils.greenlet import spawn_test_server, teardown_test_server
 
 
 class TestTFTPServer(unittest.TestCase):
     def setUp(self):
-        # initialize the file system.
         conpot_core.initialize_vfs()
+
+        self.tftp_server, self.greenlet = spawn_test_server(
+            TftpServer, template="default", protocol="tftp"
+        )
+
+        self.client = TftpClient(
+            self.tftp_server.server.server_host, self.tftp_server.server.server_port
+        )
         self._test_file = "/".join(
             conpot.__path__ + ["tests/data/test_data_fs/tftp/test.txt"]
         )
-        # get the current directory
-        self.dir_name = os.path.dirname(conpot.__file__)
-        self.tftp_server = TftpServer(
-            self.dir_name + "/templates/default/tftp/tftp.xml",
-            self.dir_name + "/templates/default",
-            args=None,
-        )
-        self.server_greenlet = gevent.spawn(self.tftp_server.start, "127.0.0.1", 0)
-        gevent.sleep(1)
 
     def tearDown(self):
-        self.tftp_server.stop()
+        teardown_test_server(self.tftp_server, self.greenlet)
 
     @freeze_time("2018-07-15 17:51:17")
     def test_tftp_upload(self):
         """Testing TFTP upload files. """
-        client = tftpy.TftpClient("127.0.0.1", self.tftp_server.server.server_port)
-        client.upload("test.txt", self._test_file)
-        gevent.sleep(3)
+        self.client.upload("test.txt", self._test_file)
         _, _data_fs = conpot_core.get_vfs("tftp")
         [_file] = [
             i for i in _data_fs.listdir("./") if "2018-07-15 17:51:17-test-txt" in i
@@ -48,9 +44,7 @@ class TestTFTPServer(unittest.TestCase):
     @freeze_time("2018-07-15 17:51:17")
     def test_mkdir_upload(self):
         """Testing TFTP upload files - while recursively making directories as per the TFTP path."""
-        client = tftpy.TftpClient("127.0.0.1", self.tftp_server.server.server_port)
-        client.upload("/dir/dir/test.txt", self._test_file)
-        gevent.sleep(3)
+        self.client.upload("/dir/dir/test.txt", self._test_file)
         _, _data_fs = conpot_core.get_vfs("tftp")
         [_file] = [
             i for i in _data_fs.listdir("./") if "2018-07-15 17:51:17-test-txt" in i
@@ -65,10 +59,8 @@ class TestTFTPServer(unittest.TestCase):
         _dst_path = "/".join(
             conpot.__path__ + ["tests/data/data_temp_fs/tftp/download"]
         )
-        client = tftpy.TftpClient("127.0.0.1", self.tftp_server.server.server_port)
         try:
-            client.download("tftp_data.txt", _dst_path)
-            gevent.sleep(3)
+            self.client.download("tftp_data.txt", _dst_path)
             self.assertTrue(filecmp.cmp(_dst_path, self._test_file))
         finally:
             _, _data_fs = conpot_core.get_vfs("tftp")

--- a/conpot/utils/greenlet.py
+++ b/conpot/utils/greenlet.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2020  srenfo
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import os
+
+from gevent import Greenlet
+from gevent.event import Event
+
+import conpot
+from conpot import core
+
+
+class ServiceGreenlet(Greenlet):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.scheduled_once = Event()
+
+    def run(self):
+        self.scheduled_once.set()
+        super().run()
+
+
+def spawn_startable_greenlet(instance, *args, **kwargs):
+    greenlet = ServiceGreenlet.spawn(instance.start, *args, **kwargs)
+    greenlet.name = instance.__class__.__name__
+
+    return greenlet
+
+
+def spawn_test_server(server_class, template, protocol, args=None, port=0):
+    conpot_dir = os.path.dirname(conpot.__file__)
+
+    template_dir = f"{conpot_dir}/templates/{template}"
+    template_xml = f"{template_dir}/template.xml"
+    protocol_xml = f"{template_dir}/{protocol}/{protocol}.xml"
+
+    core.get_databus().initialize(template_xml)
+
+    server = server_class(
+        template=protocol_xml, template_directory=template_dir, args=args
+    )
+
+    greenlet = spawn_startable_greenlet(server, "127.0.0.1", port)
+    greenlet.scheduled_once.wait()
+
+    return server, greenlet
+
+
+def teardown_test_server(server, greenlet):
+    server.stop()
+    greenlet.get()


### PR DESCRIPTION
This PR refactors all greenlet handling, especially in test code, and fixes all bugs that were exposed in the process.

I'm sorry that this is such a big PR but it's next to impossible to chop it into independent pieces. It may be best to view this commit by commit or as a side-by-side diff rather than a unified diff.

Highlights:

* Refactor the debugging `__main__`s in the protocol servers into a single script in `bin/start_protocol.py`. Those `main`s would otherwise have been a major pain to keep up to date with these changes. The script should be able to start **all** protocol individually. It keeps the previous port choices where there were any, though that may be more confusing than necessary.
* Refactor starting and stopping of servers and greenlets in protocol tests. This also includes databus init, paths to XML files, etc.
* The test suite is much faster (by almost exactly 50% on my machine). Execution time of the TFTP tests alone went down from 12228ms to 119ms on my machine. That is not a typo. (I'll have to eat those words if it turns out the new code is broken.)
* `bin/conpot` now waits for greenlets to shut down.
* The startup delay of five seconds is gone.

There are new tests for the refactored utility code.

Bug fixes:

* `conpot_protocol` tried to override some class properties but failed
* Modbus and SNMP servers were never properly shut down
* Modbus and IEC104 would not block in their `start()` method, contrary to all other protocols

Tests for these bugs are included. (All those tests would fail on the current `master`.)


Caveats:

* There's a single TODO in the PR in `greenlets.py`. The assumption that the protocol's `start()` is fairly simple does not hold true for the HTTP server, so it is special cased there. That said, the new tests would/should catch such cases (they did for HTTP). It's hard to be certain.
* Testing of the changes consisted of running the test suite and checking that `bin/conpot` still started up with the default template. No other functional testing was done. That's because the changes are focussed on test code.
