### PR TITLE
Updated Dockerfile and documentation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,5 +52,5 @@ RUN apk del --purge wget ca-certificates
 USER conpot
 WORKDIR /home/conpot
 ENV USER=conpot
-
-CMD ["/home/conpot/.local/bin/conpot", "--template", "default", "--logfile", "/var/log/conpot/conpot.log", "-f", "--temp_dir", "/tmp" ]
+ENTRYPOINT ["/home/conpot/.local/bin/conpot"]
+CMD ["--template", "default", "--logfile", "/var/log/conpot/conpot.log", "-f", "--temp_dir", "/tmp" ]

--- a/docs/source/installation/quick_install.rst
+++ b/docs/source/installation/quick_install.rst
@@ -9,8 +9,7 @@ Via a pre-built image
 1. Install `Docker`_
 2. Run ``docker pull honeynet/conpot``
 3. Run
-   ``docker run -it -p 80:80 -p 102:102 -p 502:502 -p 161:161/udp --network=bridge honeynet/conpot:latest /bin/sh``
-4. Finally run ``conpot -f --template default``
+   ``docker run -it -p 80:8800 -p 102:10201 -p 502:5020 -p 161:16100/udp --network=bridge honeynet/conpot``
 
 Navigate to ``http://MY_IP_ADDRESS`` to confirm the setup.
 


### PR DESCRIPTION
Updated the Dockerfile to execute the conpot binary when starting the container. Also changed documentation with easier command to run the container for testing and experimenting as part of the "quick start". The documentation does not match with the Dockerfile, because the conpot binary is not found in the $PATH because it's not exported for the conpot user. 