### PR TITLE
Resolve deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 gevent>=1.0
 cffi
 pysnmp
+pysnmp-mibs
 pysmi
 lxml
 bottle


### PR DESCRIPTION
Pysnmp-mibs is needed to fix a deps issue after #495 with IEC104 crashing after not finding uncompiled MIBs.