### PR TITLE
Fix FTP test leaving behind temporary files

### DIFF
--- a/conpot/tests/test_ftp.py
+++ b/conpot/tests/test_ftp.py
@@ -99,19 +99,13 @@ class TestFTPServer(unittest.TestCase):
         cmds = self.ftp_server.handler.config.enabled_commands
         [cmds.remove(i) for i in ("SITE HELP", "SITE CHMOD") if i in cmds]
         help_text = self.client.sendcmd("help")
-        self.assertTrue(all([True if i in help_text else False for i in cmds]))
+        self.assertTrue(all([i in help_text for i in cmds]))
+
         # test command specific help
-        cmds_help = {ftp_commands[k]["help"] for k in cmds}
-        self.assertTrue(
-            all(
-                [
-                    True
-                    for i in cmds
-                    if self.client.sendcmd("help {}".format(i))
-                    and i != "HELP" in cmds_help
-                ]
-            )
-        )
+        for i in cmds:
+            response = self.client.sendcmd("help {}".format(i))
+            self.assertIn(ftp_commands[i]["help"], response)
+
         # test unrecognized command
         self.assertRaisesRegex(
             ftplib.error_perm,


### PR DESCRIPTION
Fixes two bugs in the FTP tests:

1. `test_appe` was leaving behind temporary files in `conpot/tests/data/data_temp_fs/ftp`
1. `test_help` contained an assert that AFAICT was always true (the one marked "test command specific help")

Since I was already looking at the file I also refactored some test initialization code.

Caveat: I saw some occasional failures in the FTP tests which looked like race conditions to me, where one test would sometimes find a file another test had created. I don't think my particular changes are to blame but I can't be sure.