### PR TITLE
IEC104: Move station address to databus

### DIFF
--- a/conpot/protocols/IEC104/DeviceDataController.py
+++ b/conpot/protocols/IEC104/DeviceDataController.py
@@ -28,6 +28,10 @@ class DeviceDataController(object):
     def __init__(self, template):
         # key: IEC104 address, value: register object
         self.registers = {}
+        self.common_address = int(
+            conpot_core.get_databus().get_value("CommonAddress"), 0
+        )
+
         dom = etree.parse(template)
         categories = dom.xpath("//IEC104/categories/*")
 

--- a/conpot/protocols/IEC104/frames.py
+++ b/conpot/protocols/IEC104/frames.py
@@ -18,9 +18,6 @@
 from scapy.all import *
 from datetime import datetime
 
-# Station Address (maybe better in databus)
-station_addr = 0x1E28
-
 
 # Structure of control field formats
 class i_frame(Packet):
@@ -889,7 +886,7 @@ class asdu_head(Packet):
         BitField("COT", 6, 6),
         # XByteField("COT", 0x06),
         XByteField("OrigAddr", 0x00),
-        LEShortField("Addr", station_addr),
+        LEShortField("COA", 0),
     ]
 
     def __str__(self):

--- a/conpot/templates/IEC104/template.xml
+++ b/conpot/templates/IEC104/template.xml
@@ -347,6 +347,10 @@
 
 
             <!-- IEC104 Protocol parameter -->
+            <!-- Common (Object) Address, aka COA, Station Address -->
+            <key name="CommonAddress">
+                <value type="value">"0x1e28"</value>
+            </key>
             <!-- Timeout of connection establishment -->
             <key name="T_0">
                 <value type="value">30</value>

--- a/conpot/tests/test_iec104_server.py
+++ b/conpot/tests/test_iec104_server.py
@@ -34,6 +34,8 @@ class TestIEC104Server(unittest.TestCase):
             IEC104_server.IEC104Server, "IEC104", "IEC104", port=2404
         )
 
+        self.coa = self.iec104_inst.device_data_controller.common_address
+
     def tearDown(self):
         teardown_test_server(self.iec104_inst, self.greenlet)
 
@@ -73,7 +75,7 @@ class TestIEC104Server(unittest.TestCase):
 
         single_command = (
             frames.i_frame()
-            / frames.asdu_head(COT=6)
+            / frames.asdu_head(COA=self.coa, COT=6)
             / frames.asdu_infobj_45(IOA=0xEEEEEE, SCS=1)
         )
         s.send(single_command.build())
@@ -81,7 +83,7 @@ class TestIEC104Server(unittest.TestCase):
 
         bad_addr = (
             frames.i_frame(RecvSeq=0x0002)
-            / frames.asdu_head(COT=47)
+            / frames.asdu_head(COA=self.coa, COT=47)
             / frames.asdu_infobj_45(IOA=0xEEEEEE, SCS=1)
         )
         self.assertSequenceEqual(data, bad_addr.build())
@@ -105,7 +107,7 @@ class TestIEC104Server(unittest.TestCase):
 
         single_command = (
             frames.i_frame()
-            / frames.asdu_head(COT=6)
+            / frames.asdu_head(COA=self.coa, COT=6)
             / frames.asdu_infobj_45(IOA=0x141600, SCS=1)
         )
         s.send(single_command.build())
@@ -113,7 +115,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         act_conf = (
             frames.i_frame(RecvSeq=0x0002)
-            / frames.asdu_head(COT=7)
+            / frames.asdu_head(COA=self.coa, COT=7)
             / frames.asdu_infobj_45(IOA=0x141600, SCS=1)
         )
         self.assertSequenceEqual(data, act_conf.build())
@@ -121,7 +123,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         info = (
             frames.i_frame(SendSeq=0x0002, RecvSeq=0x0002)
-            / frames.asdu_head(COT=11)
+            / frames.asdu_head(COA=self.coa, COT=11)
             / frames.asdu_infobj_1(IOA=0x140D00)
         )
         info.SIQ = frames.SIQ(SPI=1)
@@ -130,7 +132,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         act_term = (
             frames.i_frame(SendSeq=0x0004, RecvSeq=0x0002)
-            / frames.asdu_head(COT=10)
+            / frames.asdu_head(COA=self.coa, COT=10)
             / frames.asdu_infobj_45(IOA=0x141600, SCS=1)
         )
         self.assertSequenceEqual(data, act_term.build())
@@ -151,7 +153,7 @@ class TestIEC104Server(unittest.TestCase):
 
         single_command = (
             frames.i_frame()
-            / frames.asdu_head(COT=6)
+            / frames.asdu_head(COA=self.coa, COT=6)
             / frames.asdu_infobj_45(IOA=0x131600, SCS=0)
         )
         s.send(single_command.build())
@@ -159,7 +161,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         act_conf = (
             frames.i_frame(RecvSeq=0x0002)
-            / frames.asdu_head(COT=7)
+            / frames.asdu_head(COA=self.coa, COT=7)
             / frames.asdu_infobj_45(IOA=0x131600, SCS=0)
         )
         self.assertSequenceEqual(data, act_conf.build())
@@ -167,7 +169,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         act_term = (
             frames.i_frame(SendSeq=0x0002, RecvSeq=0x0002)
-            / frames.asdu_head(COT=10)
+            / frames.asdu_head(COA=self.coa, COT=10)
             / frames.asdu_infobj_45(IOA=0x131600, SCS=0)
         )
         self.assertSequenceEqual(data, act_term.build())
@@ -189,7 +191,7 @@ class TestIEC104Server(unittest.TestCase):
 
         single_command = (
             frames.i_frame()
-            / frames.asdu_head(COT=6)
+            / frames.asdu_head(COA=self.coa, COT=6)
             / frames.asdu_infobj_46(IOA=0x141600, DCS=1)
         )
         s.send(single_command.build())
@@ -197,7 +199,7 @@ class TestIEC104Server(unittest.TestCase):
         data = s.recv(16)
         act_conf = (
             frames.i_frame(RecvSeq=0x0002)
-            / frames.asdu_head(PN=1, COT=7)
+            / frames.asdu_head(COA=self.coa, PN=1, COT=7)
             / frames.asdu_infobj_46(IOA=0x141600, DCS=1)
         )
         self.assertSequenceEqual(data, act_conf.build())


### PR DESCRIPTION
Set the IEC104 common address (aka station address) in the template rather than hardcoding it.

Cf. the comment at the top of`frames.py`: 

https://github.com/mushorg/conpot/blob/237b1563eeffc42c8741d5a078a2fa22b1dff772/conpot/protocols/IEC104/frames.py#L21-L22
