### PR TITLE
Fix for bytes type in JSON logging

### DIFF
--- a/conpot/core/loggers/helpers.py
+++ b/conpot/core/loggers/helpers.py
@@ -7,5 +7,7 @@ def json_default(obj):
         return obj.isoformat()
     elif isinstance(obj, uuid.UUID):
         return str(obj)
+    elif isinstance(obj, bytes):
+        return str(obj)
     else:
         return None


### PR DESCRIPTION
Possible fix for the issue #554
JSONs generated with this fix have non empty **request** and response **fields**.
Byte values are represented like this: {"request": **b'deadbeef'**} in JSON 