### PR TITLE
Delete session functionality

### DIFF
--- a/conpot/core/__init__.py
+++ b/conpot/core/__init__.py
@@ -41,6 +41,9 @@ def get_databus():
 def get_session(*args, **kwargs):
     return sessionManager.get_session(*args, **kwargs)
 
+def delete_session(*args, **kwargs):
+    return sessionManager.delete_session(*args, **kwargs)
+
 
 # file-system related  --
 

--- a/conpot/core/session_manager.py
+++ b/conpot/core/session_manager.py
@@ -55,6 +55,12 @@ class SessionManager:
             self._sessions.append(attack_session)
         return attack_session
 
+    def delete_session(self, id):
+        for i, session in enumerate(self._sessions):
+            if session.id == id:
+                del self._sessions[i]
+                break
+    
     def purge_sessions(self):
         # there is no native purge/clear mechanism for gevent queues, so...
         self.log_queue = Queue()


### PR DESCRIPTION
This is a simple delete session functionality. It is useful so that when a sessions quits or closes, it doesn't also time out after some time.