### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sphinx
 libtaxii>=1.1.0
 crc16
 natsort
-scapy==2.5.0
+scapy==2.4.5
 hpfeeds3
 modbus-tk
 stix-validator


### PR DESCRIPTION
I found out that "conpot" doesn't work with the new version of "scapy", so you should use version 2.4.5 of it.

After installing conpot, you must downgrade your scapy using

`pip install scapy==2.4.5`

This prevents the "S/E" error #585 