### PR TITLE
fix: set FakeSession.maxtimeout before pyghmi _initsession

### DIFF
--- a/conpot/protocols/ipmi/fakesession.py
+++ b/conpot/protocols/ipmi/fakesession.py
@@ -51,6 +51,9 @@ class FakeSession(Session):
         self.bmc_handlers = {}
         self.userid = userid
         self.password = password
+        # pyghmi >= 1.5 _initsession() calls _getmaxtimeout(), which needs this.
+        # Session.__init__ sets it; FakeSession does not call super().
+        self.maxtimeout = 3
         self._initsession()
         self.sockaddr = (bmc, port)
         self.server = None

--- a/conpot/tests/test_ipmi_server.py
+++ b/conpot/tests/test_ipmi_server.py
@@ -136,3 +136,11 @@ class TestIPMI(unittest.TestCase):
         # change the session pass
         result = self.run_cmd(["set", "password", "1", "TEST"])
         self.assertEqual(result, "Set session password\n")
+
+
+class TestFakeSession(unittest.TestCase):
+    def test_init_sets_maxtimeout(self):
+        from conpot.protocols.ipmi.fakesession import FakeSession
+
+        session = FakeSession("127.0.0.1", "", "", 6230)
+        self.assertEqual(session.maxtimeout, 3)


### PR DESCRIPTION
handle() built a FakeSession for every new source and crashed:

    AttributeError: 'FakeSession' object has no attribute 'maxtimeout'

pyghmi Session.__init__ sets maxtimeout; FakeSession skips that and jumps to _initsession(). From pyghmi 1.5 that method calls _getmaxtimeout(), so the greenlet died and nothing went back out.

Set maxtimeout=3 (same default as pyghmi) before _initsession().

Fixes #577
