### PR TITLE
Pr/ftp greeting code 220

### DIFF
--- a/conpot/protocols/ftp/ftp_base_handler.py
+++ b/conpot/protocols/ftp/ftp_base_handler.py
@@ -236,8 +236,8 @@ class FTPHandlerBase(socketserver.BaseRequestHandler):
             )
         )
         self.session.add_event({"type": "NEW_CONNECTION"})
-        # send 200 + banner -- new client has connected!
-        self.respond(b"200 " + self.config.banner.encode())
+        # send 220 + banner -- new client has connected! (RFC 959 greeting code)
+        self.respond(b"220 " + self.config.banner.encode())
         #  Is there a delay in command response? < gevent.sleep(0.5) ?
         return socketserver.BaseRequestHandler.setup(self)
 


### PR DESCRIPTION
# fix: use RFC 959 greeting code 220 for FTP greeting

## Problem

The FTP handler sends `200` as the initial greeting code when a client connects:

```python
# send 200 + banner -- new client has connected!
self.respond(b"200 " + self.config.banner.encode())
```

Per [[RFC 959 4.2.1](https://datatracker.ietf.org/doc/html/rfc959#section-4.2.1)](https://datatracker.ietf.org/doc/html/rfc959#section-4.2.1), `220 Service ready for new user` is the correct code for a connection greeting. `200 Command okay` is a response to a completed command and isn't valid before any command has been issued.

## Why it matters

- **Client compatibility** — some stricter FTP clients reject or warn on a non-`220` greeting.
- **Fingerprinting** — real FTP services on the devices Conpot emulates (e.g. Siemens S7 CPUs) send `220`. The `200` greeting is a trivial way to distinguish a Conpot instance from the hardware it's emulating.

## Change

One line in `conpot/protocols/ftp/ftp_base_handler.py`, plus the stale comment above it. No behavior change beyond the response code; the banner text is untouched.

```diff
-        # send 200 + banner -- new client has connected!
-        self.respond(b"200 " + self.config.banner.encode())
+        # send 220 + banner -- new client has connected! (RFC 959 greeting code)
+        self.respond(b"220 " + self.config.banner.encode())
```

## Testing

Fresh clone of this branch, `uv sync`, running the default template:

```
$ nc localhost 2121
220 FTP server ready.
```

Previously returned `200 FTP server ready.`

`black --check .` passes — 127 files unchanged.