### PR TITLE
fix: allow multiple global headers in http.xsd

### DIFF
--- a/conpot/protocols/http/http.xsd
+++ b/conpot/protocols/http/http.xsd
@@ -27,7 +27,7 @@
                             <xs:element name="headers">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="entity">
+                                        <xs:element name="entity" maxOccurs="unbounded">
                                             <xs:complexType>
                                                 <xs:simpleContent>
                                                     <xs:extension base="xs:string">


### PR DESCRIPTION
# fix: allow multiple global headers in http.xsd

## Problem

In `conpot/protocols/http/http.xsd`, the `<entity>` element inside `<global><headers>` has no `maxOccurs` attribute, so it defaults to `1`. That means a template can define exactly one global header. Adding a second causes schema validation to fail and the HTTP protocol to be skipped at startup.

The equivalent `<entity>` inside the per-node `<headers>` block already has `maxOccurs="unbounded"`, so this looks like an oversight rather than an intentional constraint.

## Reproducing

Add a second entity to the global headers block in `conpot/templates/default/http/http.xml`:

```xml
<headers>
    <entity name="X-Frame-Options">DENY</entity>
    <entity name="Date">Sat, 28 Apr 1984 07:30:00 GMT</entity>
</headers>
```

Starting Conpot with the default template then produces:

```
ERROR:root:Error parsing XML template: conpot/templates/default/http/http.xml:22:0:
ERROR:SCHEMASV:SCHEMAV_ELEMENT_CONTENT: Element 'entity': This element is not expected.
```

Conpot continues to start, but the HTTP protocol is not enabled.

## Change

One attribute on the global headers `<entity>` element:

```diff
                             <xs:element name="headers">
                                 <xs:complexType>
                                     <xs:sequence>
-                                        <xs:element name="entity">
+                                        <xs:element name="entity" maxOccurs="unbounded">
```

This only widens the schema. Templates that were valid before remain valid.

## Testing

With the fix applied and the two-header template above, Conpot starts with no schema error and serves both headers:

```
$ curl -sI http://localhost:8800/index.html
HTTP/1.1 200 OK
X-Frame-Options: DENY
Date: Fri, 04 Sep 2026 15:46:30 GMT
Last-Modified: Tue, 19 May 1993 09:00:00 GMT
Content-Type: text/html
Set-cookie: path=/
Content-Length: 603
```

The template change above was only used for testing and is not included in this PR — the commit touches `http.xsd` only.

## Motivation

I hit this while building a template that sets several security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`) globally rather than repeating them on every node. Emulating a device that sets multiple standard headers on every response currently isn't expressible in a template.