### PR TITLE
fix: expect RFC 959 FTP greeting code 220 in test_auth

### DIFF
--- a/conpot/tests/test_ftp.py
+++ b/conpot/tests/test_ftp.py
@@ -92,7 +92,7 @@ class TestFTPServer(unittest.TestCase):
     def test_auth(self):
         """Test for user, pass and quit commands."""
         # test with anonymous
-        self.assertEqual(self.client_connect(), "200 FTP server ready.")
+        self.assertEqual(self.client_connect(), "220 FTP server ready.")
         self.assertIn("Technodrome - Mouser Factory.", self.client.login())
         self.client_refresh()
         # test with registered user nobody:nobody


### PR DESCRIPTION
## Summary
- Updates `test_auth` to expect `220 FTP server ready.` after #625 changed the FTP greeting to the RFC 959-correct code.
- Unblocks the failing Code tests check on main ([run](https://github.com/mushorg/conpot/actions/runs/33953790916/job/101273297427)).

## Test plan
- [x] `uv run pytest conpot/tests/test_ftp.py::TestFTPServer::test_auth -q`
- [ ] Confirm Code tests passes on this PR


Made with [Cursor](https://cursor.com)